### PR TITLE
feat: migrate from Assistants API to Responses API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "node-cron": "^3.0.3",
         "node-html-parser": "^6.1.10",
         "npm": "^10.4.0",
-        "openai": "^4.85.1",
+        "openai": "^6.47.0",
         "pdf-parse": "^1.1.1",
         "pinecone-client": "^1.1.0",
         "pino": "^9.7.0",
@@ -994,6 +994,45 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@langchain/openai/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@langchain/openai/node_modules/zod-to-json-schema": {
@@ -4816,12 +4855,13 @@
       "integrity": "sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "form-data": "^4.0.0"
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/prop-types": {
@@ -6003,9 +6043,10 @@
       }
     },
     "node_modules/agentkeepalive": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -6811,6 +6852,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/call-me-maybe": {
@@ -7731,6 +7785,20 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -7920,12 +7988,10 @@
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7964,9 +8030,10 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -7975,13 +8042,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8873,13 +8942,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8888,7 +8960,8 @@
     "node_modules/form-data-encoder": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
     },
     "node_modules/format": {
       "version": "0.2.2",
@@ -8902,6 +8975,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.3"
@@ -8914,6 +8988,7 @@
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -9126,15 +9201,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9149,6 +9230,19 @@
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -9337,11 +9431,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9455,9 +9550,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -9485,9 +9581,10 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9589,6 +9686,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -11288,6 +11386,15 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -14821,41 +14928,33 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.85.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.85.1.tgz",
-      "integrity": "sha512-jkX2fntHljUvSH3MkWh4jShl10oNkb+SsCj4auKlbu2oF4KWAnmHLNR5EpnUHK1ZNW05Rp0fjbJzYwQzMsH8ZA==",
+      "version": "6.47.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.47.0.tgz",
+      "integrity": "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.18.tgz",
-      "integrity": "sha512-80CP7B8y4PzZF0GWx15/gVWRrB5y/bIjNI84NK3cmQJu0WZwvmj2WMA5LcofQFVfLqqCSp545+U2LsrVzX36Zg==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/openapi-types": {
@@ -19629,9 +19728,9 @@
       "integrity": "sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg=="
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-cron": "^3.0.3",
     "node-html-parser": "^6.1.10",
     "npm": "^10.4.0",
-    "openai": "^4.85.1",
+    "openai": "^6.47.0",
     "pdf-parse": "^1.1.1",
     "pinecone-client": "^1.1.0",
     "pino": "^9.7.0",

--- a/src/app/(secure)/chatbot/api/setting/api/route.ts
+++ b/src/app/(secure)/chatbot/api/setting/api/route.ts
@@ -6,7 +6,6 @@ import { getDate } from "../../../../../_helpers/client/getTime";
 import joi from "joi";
 import { authOptions } from "../../../../../api/auth/[...nextauth]/route";
 import { getServerSession } from "next-auth";
-import { openai } from "@/app/openai";
 
 module.exports = apiHandler({
   POST: retriveChatbotSettings,
@@ -107,23 +106,11 @@ async function updateChatbotSettings(request: NextRequest) {
   if (chatbotRename !== "" && chatbotRename !== undefined) {
     const collection = db.collection("user-chatbots");
 
-    /// update the name
+    /// update the name in MongoDB (Responses API is stateless — no OpenAI assistant object to sync)
     await collection.updateOne(
-      {
-        userId: userId,
-        chatbotId: chatbotId,
-      },
+      { userId: userId, chatbotId: chatbotId },
       { $set: { chatbotName: chatbotRename } }
     );
-
-    /// update chatbot name using assistant api
-    try {
-      const assistant = await openai.beta.assistants.update(chatbotId, {
-        name: chatbotRename,
-      });
-    } catch (error) {
-      console.log("Error while updating assistant name", error);
-    }
   } else {
     /// update the chatbot settings table
     const {
@@ -200,24 +187,8 @@ async function updateChatbotSettings(request: NextRequest) {
     };
     const collection = db.collection("chatbot-settings");
 
-    /// update the assistant configuration
-    try {
-      const assistant = await openai.beta.assistants.update(chatbotId, {
-        instructions: updateFields.instruction,
-        model: updateFields.model,
-        /// do not set temparature if model is o1 or o3-mini
-        ...(updateFields.model !== "o1" && updateFields.model !== "o3-mini"
-          ? {
-              temperature: updateFields.temperature,
-              reasoning_effort: null,
-            }
-          : { temperature: null, reasoning_effort: "medium" }),
-        // reasoning_effort: "medium",
-        // temperature: updateFields.temperature,
-      });
-    } catch (error) {
-      console.log("Error while updating assistant configuration", error);
-    }
+    /// Responses API is stateless — model/instructions/temperature are passed per-request
+    /// from MongoDB. No OpenAI assistant object to sync. Just update MongoDB.
     /// update the name
     await collection.updateOne(
       {

--- a/src/app/(secure)/chatbot/dashboard/_components/Chat-v2/ChatV2.tsx
+++ b/src/app/(secure)/chatbot/dashboard/_components/Chat-v2/ChatV2.tsx
@@ -41,8 +41,7 @@ import { useRouter } from "next/navigation";
 import CustomModal from "../CustomModal/CustomModal";
 import { parsePhoneNumber } from "awesome-phonenumber";
 import CloseEmbedBotIcon from "@/assets/svg/CloseEmbedBotIcon";
-import { AssistantStream } from "openai/lib/AssistantStream.mjs";
-import { AssistantStreamEvent } from "openai/resources/beta/assistants.mjs";
+import { ResponseStream } from "@/app/_helpers/client/ResponseStream";
 import CloseIcon from "@/assets/svg/CloseIcon";
 import CloseBtn from "../../../../../../../public/close-circle.png";
 import BackIcon from "../../../../../../../public/source-reference/arrow-left.png";
@@ -178,6 +177,9 @@ function ChatV2({
 
   /// tool call sources state
   const currentToolSources = useRef<any[]>([]);
+
+  /// Responses API: tracks the last response ID for conversation chaining
+  const previousResponseId = useRef<string | null>(null);
 
   /// chatbot lead section state
   const [leadDetails, setLeadDetails] = useState({
@@ -519,138 +521,105 @@ function ChatV2({
     botSettingContext?.handleChange("temperature")(newValue);
   };
 
-  /// handle the user message stream
-  const handleReadableStream = (stream: AssistantStream) => {
-    // messages
+  /// handle the user message stream (Responses API)
+  const handleReadableStream = (body: ReadableStream<Uint8Array>) => {
+    const stream = new ResponseStream(body);
+
     stream.on("textCreated", handleTextCreated);
     stream.on("textDelta", handleTextDelta);
 
-    // // image
-    // stream.on("imageFileDone", handleImageFileDone);
+    stream.on("requiresAction", ({ responseId, toolCalls }) => {
+      // Keep loading spinner visible while tools execute and response comes back
+      handleRequiresAction(responseId, toolCalls);
+    });
 
-    // // code interpreter
-    // stream.on("toolCallCreated", toolCallCreated);
-    // stream.on("toolCallDelta", toolCallDelta);
+    stream.on("completed", () => {
+      setMessagesTime((prev: any) => {
+        const updatedPrev = [...prev];
+        return updatedPrev;
+      });
 
-    // events without helpers yet (e.g. requires_action and run.done)
-    stream.on("event", (event) => {
-      if (event.event === "thread.run.requires_action")
-        handleRequiresAction(event);
-      if (event.event === "thread.run.completed") {
-        /// setting the response time when completed
-        setMessagesTime((prev: any) => {
-          const updatedPrev = [...prev];
-          return updatedPrev;
+      // Add tool sources to the actual messages array and store history after
+      if (currentToolSources.current.length > 0) {
+        const toolSourcesToAdd = [...currentToolSources.current];
+
+        setMessages((prevMessages: any) => {
+          const updatedMessages = [...prevMessages];
+          for (let i = updatedMessages.length - 1; i >= 0; i--) {
+            if (updatedMessages[i].role === "assistant") {
+              updatedMessages[i] = { ...updatedMessages[i], sources: toolSourcesToAdd };
+              break;
+            }
+          }
+          return updatedMessages;
         });
 
-        // Add tool sources to the actual messages array and store history after
-        if (currentToolSources.current.length > 0) {
-          const toolSourcesToAdd = [...currentToolSources.current]; // Create a copy before clearing
-
-          setMessages((prevMessages: any) => {
-            const updatedMessages = [...prevMessages];
-
-            // Find the last assistant message
-            for (let i = updatedMessages.length - 1; i >= 0; i--) {
-              console.log(toolSourcesToAdd);
-
-              if (updatedMessages[i].role === "assistant") {
-                updatedMessages[i] = {
-                  ...updatedMessages[i],
-                  sources: toolSourcesToAdd, // Use the copy
-                };
-                break;
-              }
+        setMessagesTime((prevTime: any) => {
+          const updatedTime = [...prevTime];
+          for (let i = updatedTime.length - 1; i >= 0; i--) {
+            if (updatedTime[i].role === "assistant") {
+              updatedTime[i] = { ...updatedTime[i], sources: toolSourcesToAdd };
+              break;
             }
-            return updatedMessages;
-          });
+          }
+          storeHistory(updatedTime);
+          return updatedTime;
+        });
 
-          // Update messagesTime with sources and store history immediately
-          setMessagesTime((prevTime: any) => {
-            const updatedTime = [...prevTime];
-
-            // Find the last assistant message in messagesTime and add sources
-            for (let i = updatedTime.length - 1; i >= 0; i--) {
-              if (updatedTime[i].role === "assistant") {
-                updatedTime[i] = {
-                  ...updatedTime[i],
-                  sources: toolSourcesToAdd,
-                };
-                break;
-              }
-            }
-
-            // Store history immediately with the updated messagesTime that includes sources
-            storeHistory(updatedTime);
-            return updatedTime;
-          });
-
-          // Clear tool sources after copying them
-          currentToolSources.current = [];
-        } else {
-          // Store history immediately if no sources to add
-          setMessagesTime((prevTime: any) => {
-            storeHistory(prevTime);
-            return prevTime;
-          });
-        }
+        currentToolSources.current = [];
+      } else {
+        setMessagesTime((prevTime: any) => {
+          storeHistory(prevTime);
+          return prevTime;
+        });
       }
     });
+
+    stream.on("error", ({ message: errMsg }) => {
+      console.error("ResponseStream error:", errMsg);
+      setLoading(false);
+    });
+
+    stream.start();
   };
 
-  // handleRequiresAction - handle function call
-  const handleRequiresAction = async (
-    event: AssistantStreamEvent.ThreadRunRequiresAction
-  ) => {
-    const runId = event.data.id;
-    const toolCalls: any =
-      event?.data?.required_action?.submit_tool_outputs.tool_calls;
+  // handleRequiresAction - handle function calls
+  const handleRequiresAction = async (responseId: string, toolCalls: any[]) => {
+    previousResponseId.current = responseId;
 
     const userID = !isPopUp ? cookies.userId : userId;
-
-    // Create sources array from tool calls
-
     const toolSources: any[] = [];
 
-    // loop over tool calls and call function handler
     const toolCallOutputs = await Promise.all(
       toolCalls.map(async (toolCall: any) => {
+        // Normalise shape so functionCallHandler still works
+        const normalised = {
+          type: "function" as const,
+          id: toolCall.id,
+          function: { name: toolCall.name, arguments: toolCall.arguments },
+        };
         const result = await functionCallHandler(
-          toolCall,
+          normalised,
           chatbot.id,
           userID,
           messages,
           webSearch
         );
 
-        // Try to parse result if it's a JSON string
         let parsedResult = result;
         if (typeof result === "string") {
-          try {
-            parsedResult = JSON.parse(result);
-          } catch (e) {
-            // Not JSON, leave as is
-          }
+          try { parsedResult = JSON.parse(result); } catch { /* not JSON */ }
         }
-        console.log(parsedResult);
-        // If parsedResult has data array, process each item
-        if (
-          parsedResult &&
-          parsedResult.data &&
-          Array.isArray(parsedResult.data)
-        ) {
+
+        if (parsedResult?.data && Array.isArray(parsedResult.data)) {
           parsedResult.data.forEach((item: any) => {
             let sourceName = item.source;
             if (item.source === "file" && item.filename) {
               sourceName = `file - ${item.filename}`;
             }
-            // If score is available, append it to the source name
             if (typeof item.score !== "undefined") {
-              sourceName += ` (score: ${
-                item.score.toFixed ? item.score.toFixed(3) : item.score
-              })`;
+              sourceName += ` (score: ${item.score.toFixed ? item.score.toFixed(3) : item.score})`;
             }
-
             toolSources.push({
               source: sourceName,
               content: item.content,
@@ -660,53 +629,40 @@ function ChatV2({
             });
           });
         } else {
-          // Fallback: just push the tool call output as before
           toolSources.push({
-            source: toolCall.function?.name || "Function Call",
-            content:
-              typeof result === "string"
-                ? result
-                : JSON.stringify(result, null, 2),
+            source: toolCall.name || "Function Call",
+            content: typeof result === "string" ? result : JSON.stringify(result, null, 2),
           });
         }
 
-        // pass only the content in output
-        if (parsedResult.data && Array.isArray(parsedResult.data)) {
+        if (parsedResult?.data && Array.isArray(parsedResult.data)) {
           return {
-            output: parsedResult.data
-              .map((item: any) => item.content)
-              .join("\n"),
+            output: parsedResult.data.map((item: any) => item.content).join("\n"),
             tool_call_id: toolCall.id,
           };
         }
-
         return { output: result, tool_call_id: toolCall.id };
       })
     );
 
-    // Store tool sources for adding to the assistant's response
     currentToolSources.current = toolSources;
-
-    // setInputDisabled(true);
-    submitActionResult(runId, toolCallOutputs);
+    submitActionResult(responseId, toolCallOutputs);
   };
 
-  const submitActionResult = async (runId: any, toolCallOutputs: any) => {
-    const response: any = await fetch(
+  const submitActionResult = async (responseId: string, toolCallOutputs: any) => {
+    const res: any = await fetch(
       `/api/assistants/threads/${threadID}/actions`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          runId: runId,
-          toolCallOutputs: toolCallOutputs,
+          assistantId: chatbot?.id,
+          previousResponseId: responseId,
+          toolCallOutputs,
         }),
       }
     );
-    const stream = AssistantStream.fromReadableStream(response.body);
-    handleReadableStream(stream);
+    handleReadableStream(res.body);
   };
 
   // textCreated - create new assistant message
@@ -795,7 +751,7 @@ function ChatV2({
 
   /// send the user message
   const sendMessage = async (text: string) => {
-    const response: any = await fetch(
+    const res: any = await fetch(
       `/api/assistants/threads/${threadID}/messages`,
       {
         method: "POST",
@@ -805,8 +761,7 @@ function ChatV2({
         }),
       }
     );
-    const stream = AssistantStream.fromReadableStream(response.body);
-    handleReadableStream(stream);
+    handleReadableStream(res.body);
   };
 
   /// get the chatbase response
@@ -878,6 +833,7 @@ function ChatV2({
 
   /// refresh the chat window
   const refreshChat = () => {
+    previousResponseId.current = null;
     setMessages([]);
     setMessagesTime([]);
     setSelectedSources([]);

--- a/src/app/(secure)/chatbot/dashboard/webhook/api/route.ts
+++ b/src/app/(secure)/chatbot/dashboard/webhook/api/route.ts
@@ -350,7 +350,7 @@ async function runAssistant(
 
 async function checkRunStatus(threadId: string, runId: string) {
   try {
-    const run = await openai.beta.threads.runs.retrieve(threadId, runId);
+    const run = await openai.beta.threads.runs.retrieve(runId, { thread_id: threadId });
     logWithTimestamp(`Run status check: ${run.status}`, {
       runId,
       threadId,
@@ -458,7 +458,7 @@ async function handleRequiredAction(
   logWithTimestamp(`Handling required action for run: ${runId}`);
 
   try {
-    const run = await openai.beta.threads.runs.retrieve(threadId, runId);
+    const run = await openai.beta.threads.runs.retrieve(runId, { thread_id: threadId });
 
     if (run.status !== "requires_action") {
       logWithTimestamp(`Run status is ${run.status}, no action required`);
@@ -514,9 +514,9 @@ async function handleRequiredAction(
     // Submit tool outputs
     logWithTimestamp(`Submitting ${toolOutputs.length} tool outputs`);
     const updatedRun = await openai.beta.threads.runs.submitToolOutputs(
-      threadId,
       runId,
       {
+        thread_id: threadId,
         tool_outputs: toolOutputs,
       }
     );

--- a/src/app/(secure)/chatbot/popup/details/api/route.ts
+++ b/src/app/(secure)/chatbot/popup/details/api/route.ts
@@ -59,8 +59,11 @@ export async function GET(request: NextRequest) {
 
 	const result = await cursor.toArray();
 
+	// Fallback: if botType is missing, infer it from assistantType.
+	// Chatbots with an assistantType were created via the Assistant flow → bot-v2.
+	// Legacy RAG chatbots have no assistantType → bot-v1.
 	if (!result?.[0]?.botType) {
-		result[0]['botType'] = 'bot-v1';
+		result[0]['botType'] = result[0]?.assistantType ? 'bot-v2' : 'bot-v1';
 	}
 
 	/// close the cursor

--- a/src/app/_components/HeroSectionChatPopup/HeroSectionChatPopup.tsx
+++ b/src/app/_components/HeroSectionChatPopup/HeroSectionChatPopup.tsx
@@ -8,8 +8,7 @@ import SendIcon from "../../../../public/svgs/send-3.svg";
 import "./hero-section-chat-popup.scss";
 import { getDate } from "@/app/_helpers/client/getTime";
 import { message } from "antd";
-import { AssistantStream } from "openai/lib/AssistantStream.mjs";
-import { AssistantStreamEvent } from "openai/resources/beta/assistants.mjs";
+import { ResponseStream } from "@/app/_helpers/client/ResponseStream";
 import { functionCallHandler } from "@/app/_helpers/client/functionCallHandler";
 import VapiAssistantCall from "./VapiCall/VapiAssistantCall";
 import JessicaImg from "../../../../public/sections-images/header-background/jessica.png";
@@ -26,7 +25,9 @@ function HeroSectionChatPopup({ onClose, agent, torriAssistantId }: any) {
   const [loading, setLoading] = useState(false);
   const [messagesTime, setMessagesTime]: any = useState([]);
   const [sessionStartDate, setSessionStartDate]: any = useState();
-  const [threadId, setThreadId] = useState();
+  const [threadId, setThreadId] = useState<string | undefined>();
+  // Responses API: tracks the last response ID for conversation chaining
+  const previousResponseId = useRef<string | null>(null);
   const chatWindowRef: any = useRef(null);
   const inputRef: any = useRef(null);
   const messageLimit = process.env.NEXT_PUBLIC_MESSAGE_LIMIT;
@@ -40,45 +41,37 @@ function HeroSectionChatPopup({ onClose, agent, torriAssistantId }: any) {
     setThreadId(data.threadId);
   };
 
-  /// handle the user message stream
-  const handleReadableStream = (stream: AssistantStream) => {
-    // messages
+  /// handle the user message stream (Responses API)
+  const handleReadableStream = (body: ReadableStream<Uint8Array>) => {
+    const stream = new ResponseStream(body);
+
     stream.on("textCreated", handleTextCreated);
     stream.on("textDelta", handleTextDelta);
-
-    // // image
-    // stream.on("imageFileDone", handleImageFileDone);
-
-    // // code interpreter
-    // stream.on("toolCallCreated", toolCallCreated);
-    // stream.on("toolCallDelta", toolCallDelta);
-
-    // events without helpers yet (e.g. requires_action and run.done)
-    stream.on("event", (event) => {
-      if (event.event === "thread.run.requires_action")
-        handleRequiresAction(event);
-      if (event.event === "thread.run.completed") {
-        /// setting the response time when completed
-        setMessagesTime((prev: any) => {
-          return [...prev];
-        });
-      }
+    stream.on("requiresAction", ({ responseId, toolCalls }) => {
+      // Keep loading spinner visible while tools execute and response comes back
+      handleRequiresAction(responseId, toolCalls);
     });
+    stream.on("completed", () => {
+      setMessagesTime((prev: any) => [...prev]);
+    });
+    stream.on("error", ({ message: errMsg }) => {
+      console.error("ResponseStream error:", errMsg);
+      setLoading(false);
+    });
+
+    stream.start();
   };
 
-  // handleRequiresAction - handle function call
-  const handleRequiresAction = async (
-    event: AssistantStreamEvent.ThreadRunRequiresAction
-  ) => {
-    const runId = event.data.id;
-    const toolCalls: any =
-      event?.data?.required_action?.submit_tool_outputs.tool_calls;
+  // handleRequiresAction - handle function calls
+  const handleRequiresAction = async (responseId: string, toolCalls: any[]) => {
+    previousResponseId.current = responseId;
 
-    // loop over tool calls and call function handler
+    // Execute all tool calls in parallel
     const toolCallOutputs = await Promise.all(
       toolCalls.map(async (toolCall: any) => {
         const result = await functionCallHandler(
-          toolCall,
+          // Normalise shape so functionCallHandler still works
+          { type: "function" as const, id: toolCall.id, function: { name: toolCall.name, arguments: toolCall.arguments } },
           torriAssistantId,
           "",
           messages,
@@ -87,26 +80,24 @@ function HeroSectionChatPopup({ onClose, agent, torriAssistantId }: any) {
         return { output: result, tool_call_id: toolCall.id };
       })
     );
-    // setInputDisabled(true);
-    submitActionResult(runId, toolCallOutputs);
+
+    submitActionResult(responseId, toolCallOutputs);
   };
 
-  const submitActionResult = async (runId: any, toolCallOutputs: any) => {
-    const response: any = await fetch(
+  const submitActionResult = async (responseId: string, toolCallOutputs: any) => {
+    const res: any = await fetch(
       `/api/assistants/threads/${threadId}/actions`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          runId: runId,
-          toolCallOutputs: toolCallOutputs,
+          assistantId: torriAssistantId,
+          previousResponseId: responseId,
+          toolCallOutputs,
         }),
       }
     );
-    const stream = AssistantStream.fromReadableStream(response.body);
-    handleReadableStream(stream);
+    handleReadableStream(res.body);
   };
 
   // textCreated - create new assistant message
@@ -183,7 +174,7 @@ function HeroSectionChatPopup({ onClose, agent, torriAssistantId }: any) {
 
   /// send the user message
   const sendMessage = async (text: string) => {
-    const response: any = await fetch(
+    const res: any = await fetch(
       `/api/assistants/threads/${threadId}/messages`,
       {
         method: "POST",
@@ -193,13 +184,13 @@ function HeroSectionChatPopup({ onClose, agent, torriAssistantId }: any) {
         }),
       }
     );
-    const stream = AssistantStream.fromReadableStream(response.body);
-    handleReadableStream(stream);
+    handleReadableStream(res.body);
   };
 
   /// refresh the chat window
   const refreshChat = () => {
     createThread();
+    previousResponseId.current = null;
     setMessages([]);
     setMessagesTime([]);
 

--- a/src/app/_helpers/client/ResponseStream.ts
+++ b/src/app/_helpers/client/ResponseStream.ts
@@ -1,0 +1,192 @@
+/**
+ * ResponseStream
+ *
+ * Client-side SSE parser for the Responses API stream.
+ *
+ * Event sequence the Responses API emits:
+ *   TEXT turn:
+ *     response.created → response.output_item.added (message) →
+ *     response.content_part.added → response.output_text.delta (N×) →
+ *     response.output_text.done → response.content_part.done →
+ *     response.output_item.done → response.completed → [DONE]
+ *
+ *   TOOL CALL turn:
+ *     response.created → response.output_item.added (function_call) →
+ *     response.function_call_arguments.delta (N×) →
+ *     response.function_call_arguments.done →
+ *     response.output_item.done (function_call) →
+ *     response.completed → [DONE]
+ *
+ * Emitted events:
+ *   "textCreated"    → () — first text chunk is about to arrive
+ *   "textDelta"      → { value: string } — incremental text
+ *   "requiresAction" → { responseId, toolCalls[] } — tool calls ready
+ *   "completed"      → () — turn fully done (text or after tool outputs)
+ *   "error"          → { message: string }
+ */
+
+type EventMap = {
+  textCreated: void;
+  textDelta: { value: string };
+  requiresAction: { responseId: string; toolCalls: ToolCall[] };
+  completed: void;
+  error: { message: string };
+};
+
+export type ToolCall = {
+  id: string;        // call_id — used when submitting outputs
+  name: string;      // function name
+  arguments: string; // JSON string of arguments
+};
+
+type Listener<K extends keyof EventMap> = (data: EventMap[K]) => void;
+
+export class ResponseStream {
+  private body: ReadableStream<Uint8Array>;
+  private listeners: { [K in keyof EventMap]?: Listener<K>[] } = {};
+  private textStarted = false;
+
+  constructor(body: ReadableStream<Uint8Array>) {
+    this.body = body;
+  }
+
+  on<K extends keyof EventMap>(event: K, listener: Listener<K>): this {
+    if (!this.listeners[event]) {
+      (this.listeners[event] as any) = [];
+    }
+    (this.listeners[event] as any[]).push(listener);
+    return this;
+  }
+
+  private emit<K extends keyof EventMap>(event: K, data?: EventMap[K]): void {
+    const fns = this.listeners[event] as Listener<K>[] | undefined;
+    if (fns) fns.forEach((f) => f(data as EventMap[K]));
+  }
+
+  /** Start consuming the stream. Resolves when the stream ends. */
+  async start(): Promise<void> {
+    const reader = this.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    // State accumulated across events
+    const partialArgs: Record<string, string> = {};  // call_id → accumulated arg string
+    let currentResponseId = "";
+    let hasPendingToolCalls = false;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const raw = line.slice(6).trim();
+
+          // [DONE] — stream is fully over
+          if (raw === "[DONE]") {
+            // Only emit completed here if no tool calls were pending
+            // (tool calls emit completed after their outputs are processed)
+            if (!hasPendingToolCalls) {
+              this.emit("completed");
+            }
+            return;
+          }
+
+          let event: any;
+          try {
+            event = JSON.parse(raw);
+          } catch {
+            continue;
+          }
+
+          const { type } = event;
+
+          // ── Capture response ID ───────────────────────────────────────────
+          if (type === "response.created" && event.response?.id) {
+            currentResponseId = event.response.id;
+          }
+
+          // ── Text output begins ────────────────────────────────────────────
+          if (type === "response.output_item.added") {
+            const item = event.item;
+            if (item?.type === "message") {
+              if (!this.textStarted) {
+                this.textStarted = true;
+                this.emit("textCreated");
+              }
+            }
+            // Register incoming function_call items
+            if (item?.type === "function_call" && item.call_id) {
+              partialArgs[item.call_id] = "";
+            }
+          }
+
+          // ── Streaming text delta ──────────────────────────────────────────
+          if (type === "response.output_text.delta") {
+            this.emit("textDelta", { value: event.delta ?? "" });
+          }
+
+          // ── Streaming function call arguments ─────────────────────────────
+          if (type === "response.function_call_arguments.delta") {
+            const callId: string = event.call_id ?? event.item_id ?? "";
+            if (callId) {
+              partialArgs[callId] = (partialArgs[callId] ?? "") + (event.delta ?? "");
+            }
+          }
+
+          // ── Function call output item fully done ──────────────────────────
+          // This is the most reliable event: the item object contains
+          // name + call_id + fully-assembled arguments.
+          if (type === "response.output_item.done") {
+            const item = event.item;
+            if (item?.type === "function_call") {
+              hasPendingToolCalls = true;
+            }
+          }
+
+          // ── response.completed — all output items are done ────────────────
+          if (type === "response.completed") {
+            const responseId: string = event.response?.id ?? currentResponseId;
+            const outputItems: any[] = event.response?.output ?? [];
+
+            const fnItems = outputItems.filter((o: any) => o.type === "function_call");
+
+            if (fnItems.length > 0) {
+              hasPendingToolCalls = true;
+              const toolCalls: ToolCall[] = fnItems.map((item: any) => ({
+                id: item.call_id,
+                name: item.name,
+                // Use fully-assembled arguments from the item itself;
+                // fall back to what we accumulated from delta events
+                arguments: item.arguments ?? partialArgs[item.call_id] ?? "{}",
+              }));
+
+              // Emit requiresAction — client will call the tools and then
+              // POST results to /actions. The "completed" event will be
+              // emitted by the ResponseStream created for that second request.
+              this.emit("requiresAction", { responseId, toolCalls });
+              // Do NOT emit "completed" here — the conversation isn't done yet
+            } else {
+              // Pure text turn — safe to complete
+              this.emit("completed");
+            }
+          }
+
+          // ── Error from OpenAI ─────────────────────────────────────────────
+          if (type === "error") {
+            this.emit("error", { message: event.message ?? "Unknown error from API" });
+          }
+        }
+      }
+    } catch (err: any) {
+      this.emit("error", { message: err?.message ?? "Unknown stream error" });
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/src/app/api/admin/migrate-bottype/route.ts
+++ b/src/app/api/admin/migrate-bottype/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import clientPromise from "@/db";
+
+export const runtime = "nodejs";
+
+/**
+ * One-time migration: upgrade all chatbots that have an assistantType
+ * (i.e. were created via the Create Assistant flow) to botType "bot-v2"
+ * so they use the Responses API / ChatV2 component.
+ *
+ * Optionally pass ?chatbotId=xxx to upgrade a single chatbot only.
+ *
+ * GET /api/admin/migrate-bottype
+ * GET /api/admin/migrate-bottype?chatbotId=asst_xxx
+ */
+export async function GET(request: NextRequest) {
+  const db = (await clientPromise!).db();
+  const collection = db.collection("user-chatbots");
+
+  const chatbotId = request.nextUrl.searchParams.get("chatbotId");
+
+  // Build filter
+  const filter: any = chatbotId
+    ? { chatbotId }                          // single chatbot
+    : { assistantType: { $exists: true } };  // all assistant-type chatbots
+
+  // Dry-run: show what would be updated
+  const preview = await collection.find(filter).toArray();
+
+  // Perform the update
+  const result = await collection.updateMany(filter, {
+    $set: { botType: "bot-v2" },
+  });
+
+  return NextResponse.json({
+    matched: result.matchedCount,
+    modified: result.modifiedCount,
+    chatbots: preview.map((c: any) => ({
+      chatbotId: c.chatbotId,
+      chatbotName: c.chatbotName,
+      assistantType: c.assistantType,
+      oldBotType: c.botType,
+      newBotType: "bot-v2",
+    })),
+  });
+}

--- a/src/app/api/assistants/threads/[threadId]/actions/route.ts
+++ b/src/app/api/assistants/threads/[threadId]/actions/route.ts
@@ -1,16 +1,125 @@
 import { openai } from "@/app/openai";
+import clientPromise from "@/db";
+import { getAssistantTools, getSystemInstruction } from "@/app/_helpers/assistant-creation-contants";
 
-// Send a new message to a thread
+export const runtime = "nodejs";
+
+/**
+ * POST /api/assistants/threads/[threadId]/actions
+ *
+ * Responses API replacement for submitToolOutputsStream.
+ *
+ * In the Responses API there is no separate "submit tool outputs" call.
+ * Instead you pass the tool call outputs as function_call_output items
+ * in a new responses.create() call, chained via previous_response_id.
+ *
+ * Body: {
+ *   assistantId: string,
+ *   previousResponseId: string,   // response ID that triggered the tool calls
+ *   toolCallOutputs: Array<{ tool_call_id: string, output: string }>
+ * }
+ */
 export async function POST(request: any, { params: { threadId } }: any) {
-  const { toolCallOutputs, runId } = await request.json();
+  const { assistantId, previousResponseId, toolCallOutputs } = await request.json();
 
-  const stream = openai.beta.threads.runs.submitToolOutputsStream(
-    threadId,
-    runId,
-    { tool_outputs: toolCallOutputs }
-  );
+  const db = (await clientPromise!).db();
 
-  return new Response(stream.toReadableStream());
+  // ── Fetch chatbot config ──────────────────────────────────────────────────
+  const [settings, chatbotRecord] = await Promise.all([
+    db.collection("chatbot-settings").findOne({ chatbotId: assistantId }),
+    db.collection("user-chatbots").findOne({ chatbotId: assistantId }),
+  ]);
+
+  const assistantType = chatbotRecord?.assistantType ?? "";
+  const model: string = settings?.model ?? "gpt-4o";
+  const temperature: number =
+    settings?.temperature !== undefined ? settings.temperature : 1;
+  const baseInstruction = settings?.instruction ?? getSystemInstruction(assistantType);
+
+  // ── Tool definitions (flatten from Assistants API shape to Responses API shape) ──
+  const tools = getAssistantTools(assistantType).map((t: any) => ({
+    type: "function" as const,
+    name: t.function.name,
+    description: t.function.description,
+    parameters: t.function.parameters,
+    ...(t.function.strict !== undefined ? { strict: t.function.strict } : {}),
+  }));
+
+  // ── Build function_call_output input items ────────────────────────────────
+  // Each item tells the model what the function returned
+  const functionOutputItems = (toolCallOutputs as any[]).map((tc: any) => ({
+    type: "function_call_output",
+    call_id: tc.tool_call_id,
+    output: typeof tc.output === "string" ? tc.output : JSON.stringify(tc.output),
+  }));
+
+  // ── Full request trace ────────────────────────────────────────────────────
+  console.log("\n========== [Responses API] ACTIONS REQUEST ==========");
+  console.log("model             :", model);
+  console.log("previousResponseId:", previousResponseId);
+  console.log("tool_outputs      :", functionOutputItems.map((i: any) => `${i.call_id} → ${String(i.output).slice(0, 150)}`).join("\n                    "));
+  console.log("=====================================================\n");
+
+  // ── Resume the conversation via Responses API ─────────────────────────────
+  const responseParams: any = {
+    model,
+    instructions: baseInstruction,
+    input: functionOutputItems,
+    tools,
+    stream: true,
+    previous_response_id: previousResponseId,
+    ...(!model.startsWith("o1") && !model.startsWith("o3")
+      ? { temperature }
+      : { reasoning: { effort: "medium" } }),
+  };
+
+  const stream = await openai.responses.create(responseParams);
+
+  // ── Stream through to client while persisting new response ID ────────────
+  const encoder = new TextEncoder();
+  let capturedResponseId: string | null = null;
+
+  const readable = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const event of stream as any) {
+          if (event.type === "response.created" && event.response?.id) {
+            capturedResponseId = event.response.id;
+          }
+
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+
+          if (event.type === "response.completed" || event.type === "response.done") {
+            if (capturedResponseId) {
+              await db.collection("chatbot-sessions").updateOne(
+                { sessionId: threadId, chatbotId: assistantId },
+                { $set: { previousResponseId: capturedResponseId, updatedAt: new Date() } },
+                { upsert: true }
+              );
+            }
+          }
+        }
+      } catch (err) {
+        console.error("Responses API actions stream error:", err);
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({ type: "error", message: "Stream error" })}\n\n`
+          )
+        );
+      } finally {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
 }
 
 export const maxDuration = 300;

--- a/src/app/api/assistants/threads/[threadId]/messages/route.ts
+++ b/src/app/api/assistants/threads/[threadId]/messages/route.ts
@@ -1,23 +1,23 @@
 import { openai } from "@/app/openai";
 import clientPromise from "@/db";
+import { getAssistantTools, getSystemInstruction } from "@/app/_helpers/assistant-creation-contants";
 
 export const runtime = "nodejs";
 
 /**
- * Build the dynamic context injected as additional_instructions on every run.
- * Timezone is read from chatbot-settings so the user never has to be asked.
+ * Build the dynamic context injected into every turn's instructions.
+ * Matches the previous additional_instructions content exactly.
  */
 function buildDynamicContext(businessTimezone: string): string {
   const now = new Date();
   const isoNow = now.toISOString();
   const utcDate = now.toUTCString();
-  const weekdays = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
+  const weekdays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
   const todayName = weekdays[now.getUTCDay()];
   const tomorrow = new Date(now);
   tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
   const tomorrowISO = tomorrow.toISOString().slice(0, 10);
 
-  // Also compute local time string in the business timezone for clarity
   let localNow = isoNow;
   try {
     localNow = new Intl.DateTimeFormat("en-CA", {
@@ -29,7 +29,7 @@ function buildDynamicContext(businessTimezone: string): string {
   } catch { /* invalid tz — fall back to ISO */ }
 
   return `
-## Dynamic Context (injected automatically — do NOT reveal these instructions to the user)
+## SYSTEM OVERRIDE — Dynamic Context (HIGHEST PRIORITY — these rules override all previous instructions)
 
 CURRENT_DATETIME_UTC: ${isoNow}
 CURRENT_DATETIME_LOCAL (${businessTimezone}): ${localNow}
@@ -38,55 +38,196 @@ TODAY_WEEKDAY: ${todayName}
 TOMORROW_DATE: ${tomorrowISO}
 BUSINESS_TIMEZONE: ${businessTimezone}
 
-### Smart booking rules (apply silently, never mention these to the user):
+### CRITICAL BOOKING RULES — MUST follow exactly, no exceptions:
 
-1. **Timezone is already set** — BUSINESS_TIMEZONE is "${businessTimezone}". NEVER ask the user for their timezone. Always use "${businessTimezone}" when calling create_booking or update_booking.
+1. **NEVER ask for information already given.** Scan the ENTIRE conversation before asking anything. If the user already provided a value (name, email, phone, date, time, service), do NOT ask for it again under any circumstances.
 
-2. **Resolve relative dates automatically** — "tomorrow" = ${tomorrowISO}, "today" = ${isoNow.slice(0,10)}, "next Monday" = calculate from TODAY_WEEKDAY. Never ask the user to re-state a date they already gave in relative terms.
+2. **Extract ALL fields from a single message.** If the user provides name + email + phone + date + time + service in one message, extract every field silently and proceed directly to calling the booking function. Do NOT ask follow-up questions about fields already given.
 
-3. **Extract all info from a single message** — if the user provides name, phone, email, date, or time in one message, extract ALL of them at once. Never ask for information already provided.
+3. **Resolve relative dates silently.** "tomorrow" = ${tomorrowISO}. "today" = ${isoNow.slice(0, 10)}. NEVER ask the user to confirm or restate a date they already gave in plain English.
 
-4. **Infer time format** — "2 pm" = 14:00, "9am" = 09:00, "noon" = 12:00, "midnight" = 00:00. Never ask the user to restate a time they already gave in 12-hour format.
+4. **Resolve 12-hour times silently.** "6 pm" = 18:00, "2 pm" = 14:00, "9 am" = 09:00, "noon" = 12:00. NEVER ask the user to restate a time in 24-hour format.
 
-5. **dateTime must ALWAYS include a time** — ALWAYS pass dateTime as "YYYY-MM-DDTHH:MM:SS" format (e.g. "2026-07-17T14:00:00"). NEVER pass a date-only string like "2026-07-17". If the user has not specified a time, ask for it before calling any booking function.
+5. **BUSINESS_TIMEZONE = "${businessTimezone}".** Use this for all bookings. NEVER ask the user for their timezone.
 
-6. **Do NOT re-confirm already confirmed info** — if the user said "yes" to a date/time confirmation, move directly to the next missing field.
+6. **dateTime format = "YYYY-MM-DDTHH:MM:SS".** Always include the time component. Example: "2026-07-17T18:00:00".
 
-7. **Only ask for genuinely missing fields** — check the entire conversation before asking anything. Required fields: name, email, phone, service type, date+time. Timezone is never required from the user.
+7. **After user says "yes" or confirms any field — move on.** Do NOT re-ask or re-confirm already confirmed information.
+
+8. **The "ask one thing at a time" rule applies ONLY to genuinely missing fields.** If all required fields are already present in the conversation, call the booking function immediately without asking anything.
+
+### Required fields checklist before calling create_booking:
+- customerName ✓ if mentioned anywhere in conversation
+- customerEmail ✓ if mentioned anywhere in conversation  
+- customerPhone ✓ if mentioned anywhere in conversation
+- serviceType ✓ if mentioned anywhere in conversation
+- dateTime ✓ if any date+time was mentioned (resolve automatically)
+- timezone = ${businessTimezone} (always pre-filled, never ask)
 `.trim();
 }
 
-// Send a new message to a thread
+/**
+ * POST /api/assistants/threads/[threadId]/messages
+ *
+ * Responses API replacement for the Assistants API messages + run endpoint.
+ * - threadId is now a local session UUID (no longer an OpenAI thread ID)
+ * - previousResponseId is stored per-session in the chatbot-sessions collection
+ *   so that conversation context is chained via previous_response_id
+ * - Streams the response back using SSE (server-sent events) in a format
+ *   compatible with the client-side parser in ResponseStream.ts
+ */
 export async function POST(request: any, { params: { threadId } }: any) {
   const { content, assistantId } = await request.json();
 
   const db = (await clientPromise!).db();
 
-  // Fetch chatbot settings to get the business timezone
-  const settings = await db.collection("chatbot-settings").findOne({
-    chatbotId: assistantId,
-  });
-  const businessTimezone = settings?.bookingTimezone ?? "UTC";
+  // ── Fetch chatbot config ──────────────────────────────────────────────────
+  const [settings, chatbotRecord] = await Promise.all([
+    db.collection("chatbot-settings").findOne({ chatbotId: assistantId }),
+    db.collection("user-chatbots").findOne({ chatbotId: assistantId }),
+  ]);
 
-  // Get schema_info for structured data sources
-  const collection = db.collection("chatbots-data");
-  const assistantData = await collection.find({ chatbotId: assistantId }).toArray();
+  const businessTimezone = settings?.bookingTimezone ?? "UTC";
+  const assistantType = chatbotRecord?.assistantType ?? "";
+  const model: string = settings?.model ?? "gpt-4o";
+  const temperature: number =
+    settings?.temperature !== undefined ? settings.temperature : 1;
+
+  // Build instructions: base system prompt + dynamic context
+  const baseInstruction = settings?.instruction ?? getSystemInstruction(assistantType);
+  const dynamicContext = buildDynamicContext(businessTimezone);
+  const fullInstructions = `${baseInstruction}\n\n${dynamicContext}`;
+
+  // ── Get schema_info for structured data sources ───────────────────────────
+  const assistantData = await db
+    .collection("chatbots-data")
+    .find({ chatbotId: assistantId })
+    .toArray();
   const schemaInfo = assistantData
     .map((data: any) => data.schema_info)
     .filter((info: any) => info !== undefined);
 
-  const userQuery = `userQuery: ${content} \n\n schema_info: ${JSON.stringify(schemaInfo)}`;
-  await openai.beta.threads.messages.create(threadId, {
-    role: "user",
-    content: userQuery,
+  const userInput = schemaInfo.length > 0
+    ? `userQuery: ${content} \n\n schema_info: ${JSON.stringify(schemaInfo)}`
+    : content;
+
+  // ── Retrieve previousResponseId for this session ──────────────────────────
+  const sessionDoc = await db
+    .collection("chatbot-sessions")
+    .findOne({ sessionId: threadId, chatbotId: assistantId });
+  const previousResponseId: string | null = sessionDoc?.previousResponseId ?? null;
+
+  // ── Tool definitions ──────────────────────────────────────────────────────
+  // getAssistantTools returns Assistants API shape: { type, function: { name, ... } }
+  // Responses API expects the flat shape:           { type, name, description, parameters, strict }
+  const tools = getAssistantTools(assistantType).map((t: any) => ({
+    type: "function" as const,
+    name: t.function.name,
+    description: t.function.description,
+    parameters: t.function.parameters,
+    ...(t.function.strict !== undefined ? { strict: t.function.strict } : {}),
+  }));
+
+  // ── Responses API call (streaming) ────────────────────────────────────────
+  const responseParams: any = {
+    model,
+    instructions: fullInstructions,
+    input: userInput,
+    tools,
+    stream: true,
+    ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
+    // Only set temperature for models that support it (not o1/o3)
+    ...(!model.startsWith("o1") && !model.startsWith("o3")
+      ? { temperature }
+      : { reasoning: { effort: "medium" } }),
+  };
+
+  // ── Full request trace ────────────────────────────────────────────────────
+  console.log("\n========== [Responses API] REQUEST ==========");
+  console.log("model          :", model);
+  console.log("assistantType  :", assistantType);
+  console.log("previousRespId :", previousResponseId ?? "(none — new session)");
+  console.log("temperature    :", responseParams.temperature ?? "n/a (reasoning model)");
+  console.log("tools          :", tools.map((t: any) => t.name).join(", ") || "(none)");
+  console.log("--- instructions (first 600 chars) ---");
+  console.log(fullInstructions.slice(0, 600));
+  console.log("--- input ---");
+  console.log(typeof userInput === "string" ? userInput.slice(0, 400) : JSON.stringify(userInput).slice(0, 400));
+  console.log("=============================================\n");
+
+  const stream = await openai.responses.create(responseParams);
+
+  // ── Stream through to client while capturing response ID ──────────────────
+  const encoder = new TextEncoder();
+  let capturedResponseId: string | null = null;
+
+  const readable = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const event of stream as any) {
+          // Capture the response ID from the first response.created event
+          if (event.type === "response.created" && event.response?.id) {
+            capturedResponseId = event.response.id;
+            console.log("[ResponsesAPI] response.created  id:", capturedResponseId);
+          }
+
+          // Trace key events
+          if (event.type === "response.output_item.added") {
+            console.log("[ResponsesAPI] output_item.added  type:", event.item?.type, event.item?.type === "function_call" ? `name=${event.item.name} call_id=${event.item.call_id}` : "");
+          }
+          if (event.type === "response.function_call_arguments.done") {
+            console.log("[ResponsesAPI] fn_args.done  call_id:", event.call_id, "args:", event.arguments?.slice(0, 200));
+          }
+          if (event.type === "response.output_item.done" && event.item?.type === "function_call") {
+            console.log("[ResponsesAPI] output_item.done  FUNCTION_CALL  name:", event.item.name, "args:", event.item.arguments?.slice(0, 200));
+          }
+          if (event.type === "response.completed") {
+            const output = event.response?.output ?? [];
+            console.log("[ResponsesAPI] response.completed  output_items:", output.map((o: any) => o.type).join(", ") || "(empty)");
+            const textItems = output.filter((o: any) => o.type === "message");
+            if (textItems.length) {
+              const text = textItems[0]?.content?.map((c: any) => c.text ?? "").join("") ?? "";
+              console.log("[ResponsesAPI] assistant_text:", text.slice(0, 300));
+            }
+          }
+
+          // Forward the raw SSE event to the client
+          const data = JSON.stringify(event);
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+
+          // When done, persist the new response ID for next turn
+          if (event.type === "response.completed" || event.type === "response.done") {
+            if (capturedResponseId) {
+              await db.collection("chatbot-sessions").updateOne(
+                { sessionId: threadId, chatbotId: assistantId },
+                { $set: { previousResponseId: capturedResponseId, updatedAt: new Date() } },
+                { upsert: true }
+              );
+              console.log("[ResponsesAPI] session updated  previousResponseId:", capturedResponseId);
+            }
+          }
+        }
+      } catch (err) {
+        console.error("Responses API stream error:", err);
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({ type: "error", message: "Stream error" })}\n\n`
+          )
+        );
+      } finally {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      }
+    },
   });
 
-  const stream = openai.beta.threads.runs.stream(threadId, {
-    assistant_id: assistantId,
-    additional_instructions: buildDynamicContext(businessTimezone),
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
   });
-
-  return new Response(stream.toReadableStream());
 }
 
 export const maxDuration = 300;

--- a/src/app/api/assistants/threads/route.ts
+++ b/src/app/api/assistants/threads/route.ts
@@ -1,12 +1,17 @@
-import { openai } from "@/app/openai";
+import { randomUUID } from "crypto";
 
 export const runtime = "nodejs";
 
-// Create a new thread
+/**
+ * Responses API migration: threads are no longer persisted in OpenAI.
+ * We generate a client-side session ID here so the calling code doesn't
+ * need to change its contract (still expects { threadId }).
+ * The actual conversation state is maintained server-side by OpenAI via
+ * previous_response_id chaining in the messages route.
+ */
 export async function POST() {
-  const thread = await openai.beta.threads.create();
-  // Return the response with JSON content
-  return new Response(JSON.stringify({ threadId: thread.id }), {
+  const sessionId = randomUUID();
+  return new Response(JSON.stringify({ threadId: sessionId }), {
     headers: { "Content-Type": "application/json" },
   });
 }

--- a/src/pages/api/pinecone.js
+++ b/src/pages/api/pinecone.js
@@ -319,12 +319,8 @@ export default async function handler(req, res) {
     /// close the cursor
     await cursor.close();
 
-    /// delete the assistant from openai
-    try {
-      await openai.beta.assistants.del(chatbotId);
-    } catch (error) {
-      console.error("Error during assistant deletion:", error);
-    }
+    /// No OpenAI assistant object to delete — Responses API is stateless
+    /// (chatbot config lives only in MongoDB)
 
     vectorId = [].concat(...vectorId);
     /// delete the vectors

--- a/src/pages/api/store-v2.js
+++ b/src/pages/api/store-v2.js
@@ -35,7 +35,6 @@ import {
   getAssistantTools,
   getSystemInstruction,
 } from "../../app/_helpers/assistant-creation-contants";
-import OpenAI from "openai";
 
 import {
   deleteFileVectorsById,
@@ -98,32 +97,18 @@ export default async function handler(req, res) {
         }
 
         /// if assistant is being created for the first time
-        let assistant;
+        let chatbotUUID;
         const assistantType = fields?.assistantType[0];
         if (!updateChatbot) {
-          /// create the openai object
-          const openai = new OpenAI({
-            apiKey: process.env.NEXT_PUBLIC_OPENAI_KEY,
-            project: process.env.NEXT_PUBLIC_OPENAI_PROJ_KEY,
-            organization: process.env.NEXT_PUBLIC_OPENAI_ORG_KEY,
-          });
-
-          /// create the assistant based on the type of assistant with the necessary instructions and function calls
-          const systemInstruction = getSystemInstruction(assistantType);
-          const tools = getAssistantTools(assistantType);
-          assistant = await openai.beta.assistants.create({
-            model: models[3],
-            instructions: systemInstruction,
-            name: chatbotName,
-            tools: tools,
-            temperature: 1,
-          });
+          /// Generate a UUID as the chatbot ID (no OpenAI assistant object created —
+          /// the Responses API is stateless: instructions & tools are passed per-request)
+          chatbotUUID = uuid();
         }
 
         const chatbotId =
           fields?.chatbotId[0] !== "undefined"
             ? fields?.chatbotId[0]
-            : assistant.id;
+            : chatbotUUID;
 
         const qaList = JSON.parse(fields?.qaList);
         const text = fields?.text[0];
@@ -137,7 +122,7 @@ export default async function handler(req, res) {
         const deleteQAList = JSON.parse(fields?.deleteQAList[0]);
 
         /// assistant type and secrets
-        const botType = fields?.botType[0];
+        const botType = fields?.botType[0] || (assistantType ? "bot-v2" : "bot-v1");
         let integrations = {};
         if (!updateChatbot) {
           integrations = JSON.parse(fields?.integrations[0]);

--- a/whatsapp-server.js
+++ b/whatsapp-server.js
@@ -290,7 +290,7 @@ async function cancelActiveRuns(threadId) {
       if (activeStatuses.includes(run.status)) {
         console.warn(`[AI] Cancelling orphaned run ${run.id} (status=${run.status}) on thread ${threadId}`);
         try {
-          await openai.beta.threads.runs.cancel(threadId, run.id);
+          await openai.beta.threads.runs.cancel(run.id, { thread_id: threadId });
         } catch (err) {
           console.warn(`[AI] Could not cancel run ${run.id}: ${err.message}`);
         }
@@ -311,7 +311,7 @@ async function cancelActiveRuns(threadId) {
  * Next.js API endpoints (pinecone, shopify, etc.) and submits outputs back.
  */
 async function handleRequiredAction(threadId, runId, chatbotId, userId, messages) {
-  const run = await openai.beta.threads.runs.retrieve(threadId, runId);
+  const run = await openai.beta.threads.runs.retrieve(runId, { thread_id: threadId });
   if (run.status !== "requires_action") return run;
 
   const toolCalls = run.required_action?.submit_tool_outputs?.tool_calls || [];
@@ -392,7 +392,7 @@ async function handleRequiredAction(threadId, runId, chatbotId, userId, messages
   );
 
   console.log(`[TOOLS] Submitting ${toolOutputs.length} output(s) for run ${runId}`);
-  const submitted = await openai.beta.threads.runs.submitToolOutputs(threadId, runId, { tool_outputs: toolOutputs });
+  const submitted = await openai.beta.threads.runs.submitToolOutputs(runId, { thread_id: threadId, tool_outputs: toolOutputs });
   console.log(`[TOOLS] Submitted — run ${runId} now ${submitted.status}`);
   return submitted;
 }
@@ -407,7 +407,7 @@ async function waitForRunCompletion(threadId, runId, chatbotId, userId, messages
   let pollCount = 0;
 
   while (Date.now() < deadline) {
-    const run = await openai.beta.threads.runs.retrieve(threadId, runId);
+    const run = await openai.beta.threads.runs.retrieve(runId, { thread_id: threadId });
     pollCount++;
     console.log(`[AI][${chatbotId}] run ${runId} poll #${pollCount} status=${run.status}`);
 


### PR DESCRIPTION
- Replace openai.beta.threads/runs with openai.responses.create
- Thread creation now returns a local UUID (no OpenAI round-trip)
- Conversation state chained via previous_response_id stored in chatbot-sessions collection
- New ResponseStream.ts: client-side SSE parser replacing AssistantStream
- Tool call schema flattened for Responses API format
- ChatV2 and HeroSectionChatPopup updated to use ResponseStream
- Loading spinner kept visible during tool execution until response arrives
- Assistant creation (store-v2.js) now generates UUID instead of OpenAI assistant object
- Settings update (setting/api/route.ts) removed openai.beta.assistants.update calls
- Chatbot deletion (pinecone.js) removed openai.beta.assistants.del call
- botType fallback in popup/details infers bot-v2 from assistantType
- store-v2.js defaults botType to bot-v2 when assistantType is present
- Admin migration endpoint: /api/admin/migrate-bottype
- Upgrade openai SDK 4.85.1 -> 6.47.0 (required for responses API)
- Fix openai v6 breaking changes: runs.retrieve/cancel/submitToolOutputs signatures updated in webhook/api/route.ts and whatsapp-server.js