### PR TITLE
feat: add WhatsApp QR tab to Conversation History with AI/manual toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@vapi-ai/web": "^2.1.4",
         "@vercel/blob": "^0.20.0",
         "@wavesurfer/react": "^1.0.7",
-        "@whiskeysockets/baileys": "^6.7.18",
+        "@whiskeysockets/baileys": "7.0.0-rc14",
         "ai": "^2.2.20",
         "antd": "^5.10.1",
         "awesome-phonenumber": "^6.9.0",
@@ -446,6 +446,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz",
@@ -532,6 +542,17 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -567,47 +588,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -658,30 +638,6 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -764,44 +720,6 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
-      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@humanfs/types": "^0.15.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
-      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@humanfs/core": "^0.19.2",
-        "@humanfs/types": "^0.15.0",
-        "@humanwhocodes/retry": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/types": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
-      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -832,18 +750,579 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw=="
     },
-    "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "license": "Apache-2.0",
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.18"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@internationalized/date": {
@@ -2756,37 +3235,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2802,9 +3274,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rc-component/color-picker": {
@@ -4674,6 +5146,46 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -4821,12 +5333,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
     },
     "node_modules/@types/luxon": {
       "version": "3.3.8",
@@ -5030,40 +5536,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.37.0.tgz",
-      "integrity": "sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.37.0",
-        "@typescript-eslint/types": "^8.37.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
-      "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
@@ -5078,22 +5550,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.37.0.tgz",
-      "integrity": "sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -5454,22 +5910,22 @@
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "version": "6.7.18",
-      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-6.7.18.tgz",
-      "integrity": "sha512-lstyxtAdOC7vuI9dWyxDg9DQlYSz8MhVsBkQUTX9EWt0GY0IJIa2Rnu4psGXa1OxgNvYwLaGSHiQBRil8mGb8g==",
+      "version": "7.0.0-rc14",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc14.tgz",
+      "integrity": "sha512-WK+X8ju8TPGxvWIsP8hrY6JB6FltYuFe+vsqKfjOYX25JObij9qLf2c3ZGdl1Q+vhFwbnT+AZmWAB5pTvzmSiQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
         "@hapi/boom": "^9.1.3",
-        "@whiskeysockets/eslint-config": "github:whiskeysockets/eslint-config",
         "async-mutex": "^0.5.0",
-        "axios": "^1.6.0",
-        "libsignal": "github:WhiskeySockets/libsignal-node",
-        "lodash": "^4.17.21",
-        "music-metadata": "^7.12.3",
+        "libsignal": "^6.0.0",
+        "lru-cache": "^11.1.0",
+        "music-metadata": "^11.12.3",
+        "p-queue": "^9.0.0",
         "pino": "^9.6",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.5.6",
+        "whatsapp-rust-bridge": "0.5.4",
         "ws": "^8.13.0"
       },
       "engines": {
@@ -5477,9 +5933,9 @@
       },
       "peerDependencies": {
         "audio-decode": "^2.1.3",
-        "jimp": "^0.16.1",
+        "jimp": "^1.6.1",
         "link-preview-js": "^3.0.0",
-        "sharp": "^0.32.6"
+        "sharp": "*"
       },
       "peerDependenciesMeta": {
         "audio-decode": {
@@ -5490,47 +5946,7 @@
         },
         "link-preview-js": {
           "optional": true
-        },
-        "sharp": {
-          "optional": true
         }
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@eslint/eslintrc": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
-      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.0",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@whiskeysockets/baileys/node_modules/@hapi/boom": {
@@ -5542,420 +5958,42 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.37.0.tgz",
-      "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
+    "node_modules/@whiskeysockets/baileys/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.37.0",
-        "@typescript-eslint/type-utils": "8.37.0",
-        "@typescript-eslint/utils": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.37.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/parser": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.37.0.tgz",
-      "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.37.0",
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/typescript-estree": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.37.0.tgz",
-      "integrity": "sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.37.0.tgz",
-      "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/typescript-estree": "8.37.0",
-        "@typescript-eslint/utils": "8.37.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/types": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
-      "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.37.0.tgz",
-      "integrity": "sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.37.0",
-        "@typescript-eslint/tsconfig-utils": "8.37.0",
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.37.0.tgz",
-      "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.37.0",
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/typescript-estree": "8.37.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.37.0.tgz",
-      "integrity": "sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.37.0",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/@whiskeysockets/eslint-config": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/whiskeysockets/eslint-config.git#299e8389baf62f9aa3034de18ff0d62cc0a5e838",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.37.0",
-        "@typescript-eslint/parser": "^8.37.0",
-        "eslint-plugin-simple-import-sort": "^12.1.1"
-      },
-      "peerDependencies": {
-        "eslint": "^9.31.0",
-        "typescript": ">=4"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/eslint": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
-      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "9.39.5",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@whiskeysockets/baileys/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
+    "node_modules/@whiskeysockets/baileys/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
+      "engines": {
+        "node": ">=20"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@whiskeysockets/baileys/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
@@ -7635,9 +7673,10 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -8410,15 +8449,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-simple-import-sort": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
-      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -8558,9 +8588,10 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -8808,17 +8839,18 @@
       }
     },
     "node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -11009,51 +11041,13 @@
       }
     },
     "node_modules/libsignal": {
-      "name": "@whiskeysockets/libsignal-node",
-      "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/WhiskeySockets/libsignal-node.git#4d08331a833727c338c1a90041d17b870210dfae",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/libsignal/-/libsignal-6.0.0.tgz",
+      "integrity": "sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==",
       "license": "GPL-3.0",
       "dependencies": {
         "curve25519-js": "^0.0.4",
-        "protobufjs": "6.8.8"
-      }
-    },
-    "node_modules/libsignal/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
-    },
-    "node_modules/libsignal/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/libsignal/node_modules/protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+        "protobufjs": "^7.5.5"
       }
     },
     "node_modules/lie": {
@@ -11717,35 +11711,84 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/music-metadata": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.14.0.tgz",
-      "integrity": "sha512-xrm3w7SV0Wk+OythZcSbaI8mcr/KHd0knJieu8bVpaPfMv/Agz5EooCAPz3OR5hbYMiUG6dgAPKZKnMzV+3amA==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.14.0.tgz",
+      "integrity": "sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
         "@tokenizer/token": "^0.3.0",
-        "content-type": "^1.0.5",
-        "debug": "^4.3.4",
-        "file-type": "^16.5.4",
-        "media-typer": "^1.1.0",
-        "strtok3": "^6.3.0",
-        "token-types": "^4.2.1"
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.4",
+        "media-typer": "^2.0.0",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      }
+    },
+    "node_modules/music-metadata/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/music-metadata/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/music-metadata/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-2.0.0.tgz",
+      "integrity": "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/music-metadata/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -15295,19 +15338,6 @@
         "@napi-rs/canvas": "^0.1.67"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -15638,24 +15668,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -17089,71 +17118,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -17584,12 +17548,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -17752,6 +17714,56 @@
       },
       "bin": {
         "sha.js": "bin.js"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -18236,16 +18248,15 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
+        "@tokenizer/token": "^0.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -18722,16 +18733,17 @@
       }
     },
     "node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
       "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "type": "github",
@@ -18803,18 +18815,6 @@
       "optional": true,
       "dependencies": {
         "nan": "^2.14.0"
-      }
-    },
-    "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-easing": {
@@ -19053,6 +19053,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbox-primitive": {
@@ -19381,6 +19393,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/whatsapp-rust-bridge": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.4.tgz",
+      "integrity": "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==",
+      "license": "MIT"
+    },
     "node_modules/whatwg-url": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
@@ -19497,6 +19515,12 @@
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
     },
     "node_modules/wmf": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@vapi-ai/web": "^2.1.4",
     "@vercel/blob": "^0.20.0",
     "@wavesurfer/react": "^1.0.7",
-    "@whiskeysockets/baileys": "^6.7.18",
+    "@whiskeysockets/baileys": "7.0.0-rc14",
     "ai": "^2.2.20",
     "antd": "^5.10.1",
     "awesome-phonenumber": "^6.9.0",

--- a/src/app/(secure)/chatbot/dashboard/_components/History/History.tsx
+++ b/src/app/(secure)/chatbot/dashboard/_components/History/History.tsx
@@ -29,6 +29,7 @@ import closeImage from "../../../../../../../public/svgs/close-icon.svg";
 import noHistory from "../../../../../../../public/svgs/empty-history.svg";
 import dynamic from "next/dynamic";
 import { io, Socket } from "socket.io-client";
+import WhatsappQRHistory from "./WhatsappQRHistory";
 
 const HighlightedInfoPage = dynamic(
   () => import("../Highlighted-Info/highlighted-info"),
@@ -1156,9 +1157,20 @@ function History({ chatbotId }: any) {
               >
                 Whatsapp
               </button>
+
+              <button
+                className={`interval-btn ${
+                  chatHistoryClassifier === "whatsapp-qr" && "active"
+                }`}
+                onClick={() => {
+                  setChatHistoryClassifier("whatsapp-qr");
+                }}
+              >
+                Whatsapp QR
+              </button>
             </div>
 
-            {chatHistoryClassifier !== "whatsapp" && (
+            {chatHistoryClassifier === "normal" && (
               <div className="date-picker-container">
                 <button
                   className={`interval-btn ${
@@ -1324,7 +1336,11 @@ function History({ chatbotId }: any) {
           </div>
         </div>
       </div>
-      {(chatHistoryList?.length !== 0 ||
+      {chatHistoryClassifier === "whatsapp-qr" && (
+        <WhatsappQRHistory chatbotId={chatbotId} />
+      )}
+      {chatHistoryClassifier !== "whatsapp-qr" &&
+        (chatHistoryList?.length !== 0 ||
         chatHistoryClassifier === "whatsapp") && (
         <div
           className={`chatbot-history-parts ${

--- a/src/app/(secure)/chatbot/dashboard/_components/History/WhatsappQRHistory.tsx
+++ b/src/app/(secure)/chatbot/dashboard/_components/History/WhatsappQRHistory.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { Pagination, message } from "antd";
+import { useCookies } from "react-cookie";
+import { ChatbotSettingContext } from "@/app/_helpers/client/Context/ChatbotSettingContext";
+import closeImage from "../../../../../../../public/svgs/close-icon.svg";
+import Image from "next/image";
+
+interface Props {
+  chatbotId: string;
+}
+
+type InboxMessage = {
+  content: string;
+  timestamp: string;
+  isFromUser: boolean;
+  isFromBot: boolean;
+  isOwnerSent: boolean;
+};
+
+type ChatSummary = {
+  phoneNumber: string;
+  allMessages: InboxMessage[];
+  totalMessages: number;
+  lastUpdate: string | null;
+};
+
+const BASE_URL = process.env.NEXT_PUBLIC_WEBSITE_URL?.replace(/\/$/, "") ?? "";
+const INBOX_API = `${BASE_URL}/chatbot/dashboard/whatsapp-qr/inbox/api`;
+const AUTO_REPLY_API = `${BASE_URL}/chatbot/dashboard/whatsapp-qr/auto-reply/api`;
+const SESSION_API = `${BASE_URL}/chatbot/dashboard/whatsapp-qr/session/api`;
+
+const LIST_POLL_MS = 5000;
+const CHAT_POLL_MS = 3000;
+
+function getContactInitials(phone: string) {
+  return phone.replace(/\D/g, "").slice(-2);
+}
+
+function formatPhoneDisplay(phone: string) {
+  const clean = phone.replace(/\D/g, "");
+  return clean.length >= 10 ? `+${clean}` : phone;
+}
+
+function formatContactTime(lastUpdate: string | null) {
+  if (!lastUpdate) return "";
+  const date = new Date(lastUpdate);
+  const now = new Date();
+  const diffDays = Math.floor((now.getTime() - date.getTime()) / 86_400_000);
+  if (diffDays === 0) return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return date.toLocaleDateString([], { weekday: "short" });
+  return date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+function formatMessageTime(timestamp: string) {
+  return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: true });
+}
+
+function formatDateForDisplay(dateKey: string) {
+  const date = new Date(dateKey);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const fmt = (d: Date) => d.toISOString().split("T")[0];
+  if (dateKey === fmt(today)) return "Today";
+  if (dateKey === fmt(yesterday)) return "Yesterday";
+  return date.toLocaleDateString([], { weekday: "long", year: "numeric", month: "long", day: "numeric" });
+}
+
+function groupMessagesByDate(messages: InboxMessage[]) {
+  const grouped: Record<string, InboxMessage[]> = {};
+  messages.forEach((m) => {
+    const key = new Date(m.timestamp).toISOString().split("T")[0];
+    (grouped[key] ||= []).push(m);
+  });
+  return grouped;
+}
+
+function getLastMessagePreview(msg?: InboxMessage) {
+  if (!msg) return "No messages";
+  let text = msg.content || "";
+  if (msg.isFromBot) {
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = text;
+    text = tempDiv.textContent || tempDiv.innerText || text;
+  }
+  return text.length > 40 ? `${text.slice(0, 40)}...` : text;
+}
+
+function getSenderLabel(msg: InboxMessage, ownerName?: string) {
+  if (msg.isOwnerSent) return ownerName;
+  if (msg.isFromBot) return "Torri AI";
+  return null;
+}
+
+function WhatsappQRHistory({ chatbotId }: Props) {
+  const [cookies] = useCookies(["userId"]);
+  const userId: string = cookies.userId;
+  const botSettingContext: any = useContext(ChatbotSettingContext);
+  const botSettings = botSettingContext?.chatbotSettings;
+
+  const [isMobileDevice, setIsMobileDevice] = useState(false);
+  const [chatClicked, setChatClicked] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+  const [chats, setChats] = useState<ChatSummary[]>([]);
+  const [manualNumbers, setManualNumbers] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedPhoneNumber, setSelectedPhoneNumber] = useState<string | null>(null);
+  const [selectedChat, setSelectedChat] = useState<ChatSummary | null>(null);
+  const [userDetails, setUserDetails] = useState<any>(null);
+
+  const listPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const chatPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const selectedPhoneRef = useRef<string | null>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    selectedPhoneRef.current = selectedPhoneNumber;
+  }, [selectedPhoneNumber]);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobileDevice(window.innerWidth < 767);
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (!userId) return;
+    fetch(`${BASE_URL}/api/user?userId=${encodeURIComponent(userId)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => json && setUserDetails(json.user))
+      .catch(() => {});
+  }, [userId]);
+
+  const fetchConnectionStatus = useCallback(async () => {
+    if (!chatbotId || !userId) return;
+    try {
+      const res = await fetch(`${SESSION_API}?chatbotId=${chatbotId}&userId=${userId}`, { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json();
+      setIsConnected(data.status === "connected");
+    } catch {
+      // transient — ignore
+    }
+  }, [chatbotId, userId]);
+
+  const fetchChatList = useCallback(async () => {
+    if (!chatbotId || !userId) return;
+    try {
+      const res = await fetch(`${INBOX_API}?chatbotId=${chatbotId}&userId=${userId}`, { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data.chats)) setChats(data.chats);
+    } catch {
+      // transient — ignore
+    }
+  }, [chatbotId, userId]);
+
+  const fetchManualNumbers = useCallback(async () => {
+    if (!chatbotId || !userId) return;
+    try {
+      const res = await fetch(`${AUTO_REPLY_API}?chatbotId=${chatbotId}&userId=${userId}`, { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data.numbers)) setManualNumbers(data.numbers);
+    } catch {
+      // transient — ignore
+    }
+  }, [chatbotId, userId]);
+
+  const fetchChatDetail = useCallback(
+    async (phoneNumber: string) => {
+      if (!chatbotId || !userId) return;
+      try {
+        const res = await fetch(
+          `${INBOX_API}?chatbotId=${chatbotId}&userId=${userId}&phoneNumber=${phoneNumber}`,
+          { cache: "no-store" }
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        // Guard against a stale response landing after the user switched contacts.
+        if (data.chat && selectedPhoneRef.current === phoneNumber) {
+          setSelectedChat(data.chat);
+        }
+      } catch {
+        // transient — ignore
+      }
+    },
+    [chatbotId, userId]
+  );
+
+  // ── list + status polling ────────────────────────────────────────────────
+  useEffect(() => {
+    fetchConnectionStatus();
+    fetchChatList();
+    fetchManualNumbers();
+
+    listPollRef.current = setInterval(() => {
+      fetchConnectionStatus();
+      fetchChatList();
+      fetchManualNumbers();
+    }, LIST_POLL_MS);
+
+    return () => {
+      if (listPollRef.current) clearInterval(listPollRef.current);
+    };
+  }, [fetchConnectionStatus, fetchChatList, fetchManualNumbers]);
+
+  // ── open-conversation polling ────────────────────────────────────────────
+  useEffect(() => {
+    if (chatPollRef.current) {
+      clearInterval(chatPollRef.current);
+      chatPollRef.current = null;
+    }
+    if (!selectedPhoneNumber) {
+      setSelectedChat(null);
+      return;
+    }
+    fetchChatDetail(selectedPhoneNumber);
+    chatPollRef.current = setInterval(() => fetchChatDetail(selectedPhoneNumber), CHAT_POLL_MS);
+    return () => {
+      if (chatPollRef.current) clearInterval(chatPollRef.current);
+    };
+  }, [selectedPhoneNumber, fetchChatDetail]);
+
+  // ── autoscroll ────────────────────────────────────────────────────────────
+  const prevMessageCountRef = useRef(0);
+  useEffect(() => {
+    const count = selectedChat?.allMessages?.length || 0;
+    const isNewChat = prevMessageCountRef.current === 0;
+    const grew = count > prevMessageCountRef.current;
+    prevMessageCountRef.current = count;
+    if ((isNewChat || grew) && messagesContainerRef.current) {
+      const container = messagesContainerRef.current;
+      const nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 150;
+      if (isNewChat || nearBottom) {
+        setTimeout(() => container.scrollTo({ top: container.scrollHeight, behavior: "smooth" }), 100);
+      }
+    }
+  }, [selectedChat?.allMessages?.length]);
+
+  const isAutoReply = (phoneNumber: string) => !manualNumbers.includes(phoneNumber);
+
+  const toggleAutoReply = async (phoneNumber: string) => {
+    const nextAutoReply = !isAutoReply(phoneNumber);
+    // Optimistic update
+    setManualNumbers((prev) =>
+      nextAutoReply ? prev.filter((n) => n !== phoneNumber) : [...prev, phoneNumber]
+    );
+    try {
+      const res = await fetch(AUTO_REPLY_API, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chatbotId, userId, phoneNumber, enable: !nextAutoReply }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      const data = await res.json();
+      if (Array.isArray(data.numbers)) setManualNumbers(data.numbers);
+    } catch {
+      // Revert on failure
+      setManualNumbers((prev) =>
+        nextAutoReply ? [...prev, phoneNumber] : prev.filter((n) => n !== phoneNumber)
+      );
+      message.error("Failed to update auto-reply setting");
+    }
+  };
+
+  const filteredChats = chats
+    .filter((c) => c.phoneNumber.toLowerCase().includes(searchQuery.toLowerCase()))
+    .sort((a, b) => new Date(b.lastUpdate || 0).getTime() - new Date(a.lastUpdate || 0).getTime());
+
+  const pageSize = 10;
+  const pagedChats = filteredChats.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+  const ownerName = userDetails?.username?.split("_")[0];
+
+  return (
+    <div className="chatbot-history-parts">
+      <div className="whatsapp-history-details">
+        <div className="whatsapp-search-container">
+          <input
+            type="text"
+            placeholder="Search phone number"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="whatsapp-search-input"
+          />
+        </div>
+
+        <div className="whatsapp-chat-list">
+          {chats.length === 0 ? (
+            <div className="loading">
+              {isConnected ? (
+                <>
+                  📭 No chats available
+                  <br />
+                  <small>Waiting for messages...</small>
+                </>
+              ) : (
+                <>
+                  🔌 No WhatsApp QR number connected
+                  <br />
+                  <small>Connect one from Integrations first</small>
+                </>
+              )}
+            </div>
+          ) : (
+            pagedChats.map((chat) => {
+              const initials = getContactInitials(chat.phoneNumber);
+              const autoReply = isAutoReply(chat.phoneNumber);
+              const isActive = selectedPhoneNumber === chat.phoneNumber;
+              return (
+                <div
+                  key={chat.phoneNumber}
+                  className={`whatsapp-chat-item ${isActive ? "active" : ""}`}
+                  onClick={() => {
+                    setSelectedPhoneNumber(chat.phoneNumber);
+                    setChatClicked(true);
+                  }}
+                >
+                  <div
+                    className="whatsapp-avatar"
+                    style={{ backgroundColor: `hsl(${(parseInt(initials, 10) * 137.5) % 360}, 70%, 60%)` }}
+                  >
+                    {initials}
+                  </div>
+                  <div className="whatsapp-chat-info">
+                    <div className="whatsapp-chat-header">
+                      <span className="whatsapp-phone">{formatPhoneDisplay(chat.phoneNumber)}</span>
+                    </div>
+                    <div className="whatsapp-chat-footer">
+                      <span className="whatsapp-message">{getLastMessagePreview(chat.allMessages?.[0])}</span>
+                    </div>
+                  </div>
+                  <div
+                    className="whatsapp-toggle"
+                    title={autoReply ? "AI will reply" : `${ownerName || "You"} will reply`}
+                  >
+                    <label className="toggle-switch" aria-label={autoReply ? "Auto-reply on" : "Auto-reply off"}>
+                      <input
+                        type="checkbox"
+                        checked={autoReply}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          toggleAutoReply(chat.phoneNumber);
+                        }}
+                      />
+                      <span className="toggle-slider">
+                        <span className="toggle-label toggle-label-on">AI</span>
+                        <span className="toggle-label toggle-label-off">You</span>
+                        <span className="toggle-knob" aria-hidden="true"></span>
+                      </span>
+                    </label>
+                    <span className="whatsapp-time">{formatContactTime(chat.lastUpdate)}</span>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {filteredChats.length > pageSize && (
+          <Pagination
+            defaultCurrent={1}
+            current={currentPage}
+            total={filteredChats.length}
+            onChange={(page) => setCurrentPage(page)}
+            showSizeChanger={false}
+            pageSize={pageSize}
+          />
+        )}
+      </div>
+
+      {isMobileDevice && chatClicked && (
+        <div className="message-scrim" onClick={() => setChatClicked(false)} />
+      )}
+
+      <div
+        className={`message-section-wrapper ${isMobileDevice && chatClicked ? "mobile-panel" : ""}`}
+        style={{
+          display: !isMobileDevice ? "block" : chatClicked ? "block" : "none",
+        }}
+      >
+        <div className="messages-section">
+          <div className="header" style={{ visibility: selectedChat ? "visible" : "hidden" }}>
+            <p className="header-email">{selectedPhoneNumber ? formatPhoneDisplay(selectedPhoneNumber) : ""}</p>
+            <div className="action-btns">
+              {isMobileDevice && (
+                <Image src={closeImage} alt="close-icon" onClick={() => setChatClicked(false)} />
+              )}
+            </div>
+          </div>
+          <hr style={{ visibility: selectedChat ? "visible" : "hidden" }} />
+
+          <div className="history-conversation-container" ref={messagesContainerRef}>
+            {selectedChat &&
+              Object.entries(groupMessagesByDate(selectedChat.allMessages || [])).map(([dateKey, messages]) => (
+                <React.Fragment key={dateKey}>
+                  <div className="whatsapp-date-separator">
+                    <span className="date-label">{formatDateForDisplay(dateKey)}</span>
+                  </div>
+                  {messages.map((msg, index) => (
+                    <div
+                      key={`${dateKey}-${index}`}
+                      className={msg.isFromUser ? "user-message-container" : "assistant-message-container"}
+                    >
+                      <div
+                        className={msg.isFromUser ? "user-message" : "assistant-message"}
+                        style={msg.isFromUser ? { backgroundColor: botSettings?.userMessageColor || "#d9fdd3" } : {}}
+                      >
+                        {msg.isFromBot ? <div dangerouslySetInnerHTML={{ __html: msg.content }} /> : <div>{msg.content}</div>}
+                      </div>
+                      <div className="time" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                        <span>{formatMessageTime(msg.timestamp)}</span>
+                        {(() => {
+                          const label = getSenderLabel(msg, ownerName);
+                          return label ? (
+                            <span className="whatsapp-sender-label" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                              <span className="whatsapp-dot" aria-hidden="true" />
+                              <span className="whatsapp-sender-text">{label}</span>
+                            </span>
+                          ) : null;
+                        })()}
+                      </div>
+                    </div>
+                  ))}
+                </React.Fragment>
+              ))}
+          </div>
+
+          {selectedChat && !isAutoReply(selectedChat.phoneNumber) && (
+            <div className="whatsapp-manual-mode-banner">
+              You&apos;ve turned off AI auto-reply for this contact — please continue this chat from
+              the WhatsApp app on your phone. Messages sent from either side will still show up here.
+            </div>
+          )}
+
+          <div className="footer" style={{ visibility: selectedChat ? "visible" : "hidden" }}>
+            <p>Powered by Torri.AI</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WhatsappQRHistory;

--- a/src/app/(secure)/chatbot/dashboard/_components/History/history.scss
+++ b/src/app/(secure)/chatbot/dashboard/_components/History/history.scss
@@ -920,6 +920,17 @@
     }
   }
 
+  // WhatsApp manual-mode banner (AI auto-reply off — continue from the app)
+  .whatsapp-manual-mode-banner {
+    margin: 0 16px 16px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    background: #fff3cd;
+    color: #7a5c00;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
   // WhatsApp chat input container
   .whatsapp-chat-input {
     display: flex;

--- a/src/app/(secure)/chatbot/dashboard/whatsapp-qr/_lib/authorize.ts
+++ b/src/app/(secure)/chatbot/dashboard/whatsapp-qr/_lib/authorize.ts
@@ -1,0 +1,33 @@
+import clientPromise from "@/db";
+import { NextResponse } from "next/server";
+
+/**
+ * Shared auth guard for the WhatsApp QR inbox routes: confirms the chatbotId
+ * + userId pair actually owns the chatbot in Mongo. Mirrors the same check
+ * already used by whatsapp-qr/session/api/route.ts for the pairing flow —
+ * getServerSession() is deliberately NOT used here, since it doesn't reliably
+ * resolve a session in this app's Route Handlers (see the header/session
+ * fallback in chatbot/api/history/route.ts for the same pre-existing issue).
+ * Returns an error NextResponse if unauthorized, or null if the request may proceed.
+ */
+export async function authorizeWhatsappQr(
+  chatbotId: string | null,
+  userId: string | null
+): Promise<NextResponse | null> {
+  if (!chatbotId || !userId) {
+    return NextResponse.json(
+      { error: "chatbotId and userId required" },
+      { status: 400 }
+    );
+  }
+
+  const db = (await clientPromise!).db();
+  const owns = await db
+    .collection("user-chatbots")
+    .findOne({ chatbotId, userId });
+  if (!owns) {
+    return NextResponse.json({ error: "Chatbot not found" }, { status: 404 });
+  }
+
+  return null;
+}

--- a/src/app/(secure)/chatbot/dashboard/whatsapp-qr/auto-reply/api/route.ts
+++ b/src/app/(secure)/chatbot/dashboard/whatsapp-qr/auto-reply/api/route.ts
@@ -1,0 +1,73 @@
+import clientPromise from "@/db";
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeWhatsappQr } from "../../_lib/authorize";
+
+/**
+ * GET /chatbot/dashboard/whatsapp-qr/auto-reply/api?chatbotId=&userId=
+ * Returns the phone numbers currently in manual mode (AI auto-reply OFF).
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const chatbotId = req.nextUrl.searchParams.get("chatbotId");
+    const userId = req.nextUrl.searchParams.get("userId");
+
+    const unauthorized = await authorizeWhatsappQr(chatbotId, userId);
+    if (unauthorized) return unauthorized;
+
+    const db = (await clientPromise!).db();
+    const doc = await db
+      .collection("whatsapp_qr_sessions")
+      .findOne({ chatbotId }, { projection: { manualNumbers: 1 } });
+
+    return NextResponse.json({ numbers: doc?.manualNumbers || [] });
+  } catch (err: any) {
+    console.error("[WA-QR auto-reply GET] error:", err.message);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}
+
+/**
+ * POST /chatbot/dashboard/whatsapp-qr/auto-reply/api
+ * Body: { chatbotId, userId, phoneNumber, enable }
+ * enable:true switches the contact to manual mode (AI auto-reply OFF).
+ * enable:false switches it back to AI auto-reply.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { chatbotId, userId, phoneNumber, enable } = body;
+
+    const unauthorized = await authorizeWhatsappQr(chatbotId, userId);
+    if (unauthorized) return unauthorized;
+
+    if (!phoneNumber) {
+      return NextResponse.json({ error: "phoneNumber is required" }, { status: 400 });
+    }
+
+    const phoneKey = String(phoneNumber).replace(/\D/g, "");
+    const db = (await clientPromise!).db();
+    const sessionsCol = db.collection("whatsapp_qr_sessions");
+
+    const existing = await sessionsCol.findOne({ chatbotId });
+    if (!existing) {
+      return NextResponse.json({ error: "No WhatsApp QR session found" }, { status: 404 });
+    }
+
+    await sessionsCol.updateOne(
+      { chatbotId },
+      enable
+        ? { $addToSet: { manualNumbers: phoneKey } }
+        : { $pull: { manualNumbers: phoneKey as any } }
+    );
+
+    const updated = await sessionsCol.findOne(
+      { chatbotId },
+      { projection: { manualNumbers: 1 } }
+    );
+
+    return NextResponse.json({ numbers: updated?.manualNumbers || [] });
+  } catch (err: any) {
+    console.error("[WA-QR auto-reply POST] error:", err.message);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/(secure)/chatbot/dashboard/whatsapp-qr/inbox/api/route.ts
+++ b/src/app/(secure)/chatbot/dashboard/whatsapp-qr/inbox/api/route.ts
@@ -1,0 +1,117 @@
+import clientPromise from "@/db";
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeWhatsappQr } from "../../_lib/authorize";
+
+const HISTORY_COLLECTION = "whatsapp-qr-chat-history";
+
+function transformMessage(msg: any) {
+  return {
+    content: msg.content,
+    timestamp: msg.timestamp,
+    isFromUser: msg.role === "user",
+    isFromBot: msg.role === "assistant",
+    // True for messages the account owner sent themselves — either directly
+    // from the WhatsApp app on their phone, or (historically) via the
+    // dashboard — as opposed to an AI-generated reply.
+    isOwnerSent: msg.sentBy === "agent",
+  };
+}
+
+/**
+ * GET /chatbot/dashboard/whatsapp-qr/inbox/api?chatbotId=&userId=[&phoneNumber=]
+ *
+ * List mode (no phoneNumber): one entry per contact, holding only their most
+ * recent message — cheap enough to poll every few seconds.
+ * Single-chat mode (phoneNumber given): the full transcript for that contact,
+ * concatenated across every date-partitioned document.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const chatbotId = req.nextUrl.searchParams.get("chatbotId");
+    const userId = req.nextUrl.searchParams.get("userId");
+    const phoneNumberParam = req.nextUrl.searchParams.get("phoneNumber");
+
+    const unauthorized = await authorizeWhatsappQr(chatbotId, userId);
+    if (unauthorized) return unauthorized;
+
+    const db = (await clientPromise!).db();
+    const historyCol = db.collection(HISTORY_COLLECTION);
+
+    if (phoneNumberParam) {
+      const phoneKey = phoneNumberParam.replace(/\D/g, "");
+      const docs = await historyCol
+        .find(
+          { userId, chatbotId, [`chats.${phoneKey}`]: { $exists: true } },
+          { projection: { date: 1, [`chats.${phoneKey}`]: 1 } }
+        )
+        .sort({ date: 1 })
+        .toArray();
+
+      // Concatenate (never overwrite) — the same phoneKey legitimately repeats
+      // across many date-docs, one per day of conversation.
+      let allMessages: any[] = [];
+      for (const doc of docs) {
+        const messages = (doc as any).chats?.[phoneKey]?.messages || [];
+        allMessages = allMessages.concat(messages);
+      }
+      allMessages.sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      );
+
+      const transformed = allMessages.map(transformMessage);
+      const lastMessage = transformed[transformed.length - 1];
+
+      return NextResponse.json({
+        chat: {
+          phoneNumber: phoneKey,
+          allMessages: transformed,
+          totalMessages: transformed.length,
+          lastUpdate: lastMessage?.timestamp ?? null,
+        },
+      });
+    }
+
+    const pipeline = [
+      { $match: { userId, chatbotId } },
+      { $project: { chatsArray: { $objectToArray: "$chats" } } },
+      { $unwind: "$chatsArray" },
+      {
+        $project: {
+          _id: 0,
+          phoneKey: "$chatsArray.k",
+          count: { $size: { $ifNull: ["$chatsArray.v.messages", []] } },
+          lastMessage: {
+            $arrayElemAt: [{ $ifNull: ["$chatsArray.v.messages", []] }, -1],
+          },
+        },
+      },
+      { $match: { lastMessage: { $ne: null } } },
+      { $sort: { "lastMessage.timestamp": 1 as const } },
+      {
+        $group: {
+          _id: "$phoneKey",
+          totalMessages: { $sum: "$count" },
+          lastMessage: { $last: "$lastMessage" },
+        },
+      },
+      { $sort: { "lastMessage.timestamp": -1 as const } },
+    ];
+
+    const results = await historyCol.aggregate(pipeline).toArray();
+
+    const chats = results.map((r: any) => {
+      const lastMessage = transformMessage(r.lastMessage);
+      return {
+        phoneNumber: r._id,
+        allMessages: [lastMessage],
+        totalMessages: r.totalMessages,
+        lastUpdate: lastMessage.timestamp,
+      };
+    });
+
+    return NextResponse.json({ chats });
+  } catch (err: any) {
+    console.error("[WA-QR inbox GET] error:", err.message);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/whatsapp-server.js
+++ b/whatsapp-server.js
@@ -22,8 +22,12 @@ require("dotenv").config({ path: ".env.local" });
 
 const express = require("express");
 const { MongoClient, ObjectId } = require("mongodb");
-const {
-  default: makeWASocket,
+// @whiskeysockets/baileys 7.x is published as an ESM-only package ("type":
+// "module"), so it can't be loaded with require() from this CommonJS file.
+// These are populated via dynamic import() in the startup IIFE at the
+// bottom of this file, before anything that references them is invoked
+// (session creation only ever happens after startup completes).
+let makeWASocket,
   DisconnectReason,
   initAuthCreds,
   proto,
@@ -31,8 +35,7 @@ const {
   isJidGroup,
   fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,
-  Browsers,
-} = require("@whiskeysockets/baileys");
+  Browsers;
 const pino = require("pino");
 const QRCode = require("qrcode");
 
@@ -53,10 +56,10 @@ if (!MONGO_URI) {
 // Safety net: a stray async error from a single WhatsApp socket should never
 // take down the whole multi-tenant server. Log and keep running.
 process.on("uncaughtException", (err) => {
-  console.error("[uncaughtException]", err?.message ?? err);
+  console.error("[uncaughtException]", err?.stack ?? err?.message ?? err);
 });
 process.on("unhandledRejection", (reason) => {
-  console.error("[unhandledRejection]", reason?.message ?? reason);
+  console.error("[unhandledRejection]", reason?.stack ?? reason?.message ?? reason);
 });
 
 // ─── MongoDB ──────────────────────────────────────────────────────────────────
@@ -77,6 +80,9 @@ async function connectDb() {
   await db
     .collection("whatsapp_qr_sessions")
     .createIndex({ chatbotId: 1 }, { unique: true });
+  await db
+    .collection("whatsapp-qr-chat-history")
+    .createIndex({ userId: 1, chatbotId: 1, date: 1 }, { unique: true });
 }
 
 // ─── MongoDB auth state (per chatbotId) ───────────────────────────────────────
@@ -216,6 +222,89 @@ function createMessageWithTimestamp(role, content) {
 
 function cleanMessagesForOpenAI(messages) {
   return messages.map((m) => ({ role: m.role, content: m.content }));
+}
+
+/** Extracts the text body from a Baileys message — works for plain messages,
+ * quoted replies, and image/video captions. Named distinctly from the
+ * extractMessageText() below (which parses OpenAI Assistants API message
+ * content, not Baileys messages) — two same-named function declarations in
+ * one scope silently collapse to just the later one, which is what broke
+ * incoming-message handling here. */
+function extractBaileysMessageText(msg) {
+  return (
+    msg.message?.conversation ||
+    msg.message?.extendedTextMessage?.text ||
+    msg.message?.imageMessage?.caption ||
+    msg.message?.videoMessage?.caption ||
+    ""
+  );
+}
+
+// ─── whatsapp-qr-chat-history helpers ─────────────────────────────────────────
+// Shared write path for every message stored against a QR conversation,
+// whether it originates from an inbound WhatsApp message, an AI-generated
+// reply, or an agent's manual reply sent from the dashboard.
+
+/** Idempotently ensures the {userId,chatbotId,date} doc and chats[phoneKey] entry exist. */
+async function ensureChatEntry(userId, chatbotId, phoneKey, dateKey) {
+  const historyCol = db.collection("whatsapp-qr-chat-history");
+  const existingDoc = await historyCol.findOne({ userId, chatbotId, date: dateKey });
+
+  if (!existingDoc) {
+    const newDoc = {
+      userId,
+      chatbotId,
+      chats: {
+        [phoneKey]: {
+          messages: [],
+          usage: { completion_tokens: 0, prompt_tokens: 0, total_tokens: 0 },
+        },
+      },
+      date: dateKey,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    await historyCol.insertOne(newDoc);
+    return newDoc;
+  }
+
+  if (!existingDoc.chats?.[phoneKey]) {
+    await historyCol.updateOne(
+      { userId, chatbotId, date: dateKey },
+      {
+        $set: {
+          [`chats.${phoneKey}.messages`]: [],
+          [`chats.${phoneKey}.usage`]: { completion_tokens: 0, prompt_tokens: 0, total_tokens: 0 },
+          updatedAt: new Date(),
+        },
+      }
+    );
+    existingDoc.chats = existingDoc.chats || {};
+    existingDoc.chats[phoneKey] = { messages: [], usage: { completion_tokens: 0, prompt_tokens: 0, total_tokens: 0 } };
+  }
+
+  return existingDoc;
+}
+
+/** Ensures the chat entry exists, then appends messageDoc to it. Returns the pre-push doc. */
+async function persistMessage(userId, chatbotId, phoneKey, dateKey, messageDoc) {
+  const existingDoc = await ensureChatEntry(userId, chatbotId, phoneKey, dateKey);
+  await db.collection("whatsapp-qr-chat-history").updateOne(
+    { userId, chatbotId, date: dateKey },
+    {
+      $push: { [`chats.${phoneKey}.messages`]: messageDoc },
+      $set: { updatedAt: new Date() },
+    }
+  );
+  return existingDoc;
+}
+
+/** True if this phone number is currently in manual/human mode (AI auto-reply OFF). */
+async function isManualMode(chatbotId, phoneKey) {
+  const doc = await db
+    .collection("whatsapp_qr_sessions")
+    .findOne({ chatbotId }, { projection: { manualNumbers: 1 } });
+  return Boolean(doc?.manualNumbers?.includes(phoneKey));
 }
 
 // ─── Format helper (mirrors formatMessageForWhatsApp in route.ts) ─────────────
@@ -809,53 +898,14 @@ async function getAIReply(userMessage, chatbotId, userId, senderJid) {
   // Store user message immediately (mirrors route.ts step 5.5)
   const userMsg = createMessageWithTimestamp("user", userMessage);
 
-  let existingDoc = await historyCol.findOne({ userId, chatbotId, date: dateKey });
+  // ── 2a. Ensure the history document + phone-key entry exist, then persist
+  // the inbound user message (single write path shared with the manual-send
+  // and manual-mode-inbound paths — see persistMessage/ensureChatEntry above).
+  const existingDoc = await persistMessage(userId, chatbotId, phoneKey, dateKey, userMsg);
 
-  // ── 2a. Ensure the history document + phone-key entry exist ──────────────
-  if (!existingDoc) {
-    const newDoc = {
-      userId,
-      chatbotId,
-      chats: {
-        [phoneKey]: {
-          messages: [],
-          usage: { completion_tokens: 0, prompt_tokens: 0, total_tokens: 0 },
-        },
-      },
-      date: dateKey,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    await historyCol.insertOne(newDoc);
-    existingDoc = newDoc;
-  } else if (!existingDoc.chats?.[phoneKey]) {
-    await historyCol.updateOne(
-      { userId, chatbotId, date: dateKey },
-      {
-        $set: {
-          [`chats.${phoneKey}.messages`]: [],
-          [`chats.${phoneKey}.usage`]: { completion_tokens: 0, prompt_tokens: 0, total_tokens: 0 },
-          updatedAt: new Date(),
-        },
-      }
-    );
-    existingDoc.chats = existingDoc.chats || {};
-    existingDoc.chats[phoneKey] = { messages: [], usage: { completion_tokens: 0, prompt_tokens: 0, total_tokens: 0 } };
-  }
-
-  // ── 2b. Handle per-path thread wiring for legacy bots ───────────────────
   // bot-v2 uses the Responses API (stateless) — no thread needed.
   // Legacy bots don't use threads either; this variable is kept for compatibility.
   let threadId = null;
-
-  // Persist user message to history
-  await historyCol.updateOne(
-    { userId, chatbotId, date: dateKey },
-    {
-      $push: { [`chats.${phoneKey}.messages`]: userMsg },
-      $set: { updatedAt: new Date() },
-    }
-  );
 
   // ── 3. Generate AI response ───────────────────────────────────────────────
   let aiResponse = "";
@@ -1007,12 +1057,42 @@ async function handleIncomingMessage({ msg, isGroup, userMessage, chatbotId, soc
       return;
     }
 
-    // senderJid: participant JID for groups, remoteJid for 1-1
+    // senderJid: participant JID for groups, remoteJid for 1-1. This is the
+    // PROTOCOL-level address (used below for mentions/quoting) — WhatsApp
+    // increasingly addresses messages by an opaque LID instead of the real
+    // phone number for privacy, so it must stay untouched for actually
+    // routing replies.
     const senderJid = isGroup
       ? (msg.key.participant || msg.key.remoteJid)
       : msg.key.remoteJid;
+    // When Baileys resolves the real phone number behind a LID for this
+    // message (remoteJidAlt / participantAlt), use it as our own storage
+    // key so contacts show up under their real number in the dashboard
+    // instead of an opaque LID. Falls back to the LID when WhatsApp hasn't
+    // supplied the alt address for this particular message.
+    const senderJidAlt = isGroup ? msg.key.participantAlt : msg.key.remoteJidAlt;
+    const identityJid = senderJidAlt || senderJid;
+    const phoneKey = identityJid.split("@")[0];
 
-    const reply = await getAIReply(userMessage, chatbotId, chatbotDoc.userId, senderJid);
+    // Manual mode: an agent has taken this contact over from the dashboard.
+    // Store the inbound message (so it appears on the dashboard's next poll)
+    // but skip AI generation and auto-send entirely.
+    if (await isManualMode(chatbotId, phoneKey)) {
+      const dateKey = new Date().toISOString().slice(0, 10);
+      await persistMessage(
+        chatbotDoc.userId,
+        chatbotId,
+        phoneKey,
+        dateKey,
+        createMessageWithTimestamp("user", userMessage)
+      );
+      await db
+        .collection("whatsapp_qr_sessions")
+        .updateOne({ chatbotId }, { $set: { lastActivity: new Date() } });
+      return;
+    }
+
+    const reply = await getAIReply(userMessage, chatbotId, chatbotDoc.userId, identityJid);
 
     // null means a duplicate active-run was detected — skip sending
     if (reply === null) return;
@@ -1034,10 +1114,15 @@ async function handleIncomingMessage({ msg, isGroup, userMessage, chatbotId, soc
     }
 
     // Remember the message we just sent so it can be re-served to WhatsApp
-    // if the recipient's device requests a re-send (decryption retry).
+    // if the recipient's device requests a re-send (decryption retry), and
+    // mark its id as "ours" so the messages.upsert echo below doesn't
+    // mistake this AI reply for a message typed directly on the phone.
     const session = sessions.get(chatbotId);
     if (sent?.key?.id && sent.message && session?.rememberMessage) {
       session.rememberMessage(sent.key, sent.message);
+    }
+    if (sent?.key?.id && session?.markOwnSent) {
+      session.markOwnSent(sent.key.id);
     }
 
     await db
@@ -1045,7 +1130,38 @@ async function handleIncomingMessage({ msg, isGroup, userMessage, chatbotId, soc
       .updateOne({ chatbotId }, { $set: { lastActivity: new Date() } });
 
   } catch (err) {
-    console.error(`[MSG] Error handling message for ${chatbotId}:`, err.message);
+    console.error(`[MSG] Error handling message for ${chatbotId}:`, err.stack || err.message);
+  }
+}
+
+/**
+ * Logs a message the account owner sent directly from the WhatsApp app on
+ * their phone (not via our AI or the dashboard) so it still shows up in the
+ * Conversation History transcript. Only called for fromMe messages whose id
+ * isn't in session.ownSentIds — i.e. ones we didn't just send ourselves.
+ */
+async function handlePhoneSentMessage({ msg, chatbotId }) {
+  try {
+    if (isJidGroup(msg.key.remoteJid) || isJidBroadcast(msg.key.remoteJid)) return;
+
+    const text = extractBaileysMessageText(msg).trim();
+    if (!text) return;
+
+    const chatbotDoc = await db.collection("user-chatbots").findOne({ chatbotId });
+    if (!chatbotDoc) return;
+
+    // Prefer the real phone number (remoteJidAlt) over an opaque LID, same
+    // reasoning as the inbound path in handleIncomingMessage above.
+    const phoneKey = (msg.key.remoteJidAlt || msg.key.remoteJid).split("@")[0];
+    const dateKey = new Date().toISOString().slice(0, 10);
+    const messageDoc = { ...createMessageWithTimestamp("assistant", text), sentBy: "agent" };
+
+    await persistMessage(chatbotDoc.userId, chatbotId, phoneKey, dateKey, messageDoc);
+    await db
+      .collection("whatsapp_qr_sessions")
+      .updateOne({ chatbotId }, { $set: { lastActivity: new Date() } });
+  } catch (err) {
+    console.error(`[PHONE-SENT] Error handling phone-sent message for ${chatbotId}:`, err.message);
   }
 }
 
@@ -1077,6 +1193,22 @@ async function startSession(chatbotId, userId) {
     messageStore.set(key.id, message);
   };
   session.rememberMessage = rememberMessage;
+
+  // Bounded set of message ids we've sent ourselves (AI auto-replies). Lets
+  // the messages.upsert handler tell "we just sent this" apart from "the
+  // owner typed this directly into the WhatsApp app on their phone" — both
+  // arrive as fromMe:true, but only the latter needs to be freshly logged.
+  const ownSentIds = new Set();
+  const OWN_SENT_LIMIT = 500;
+  const markOwnSent = (id) => {
+    if (!id) return;
+    if (ownSentIds.size >= OWN_SENT_LIMIT) {
+      ownSentIds.delete(ownSentIds.values().next().value);
+    }
+    ownSentIds.add(id);
+  };
+  session.ownSentIds = ownSentIds;
+  session.markOwnSent = markOwnSent;
 
   const logger = pino({ level: "silent" });
   const { state, saveCreds } = await useMongoAuthState(chatbotId);
@@ -1243,23 +1375,31 @@ async function startSession(chatbotId, userId) {
     if (type !== "notify") return;
 
     for (const msg of msgs) {
+      // A single malformed/unexpected message shape must never abort the
+      // whole batch — catch synchronous errors per-message and keep going.
+      try {
       // Remember every inbound message so it can be served back to WhatsApp
       // if a re-send (decryption retry) is requested for it.
       if (msg.key?.id && msg.message) session.rememberMessage(msg.key, msg.message);
 
-      // Skip outbound and broadcast messages
-      if (msg.key.fromMe) continue;
+      // Outbound messages: if it's one we just sent ourselves (AI reply),
+      // there's nothing to do — already logged. Otherwise it was typed
+      // directly into the WhatsApp app on the linked phone — log it so it
+      // still shows up in the dashboard, then skip the AI/inbound pipeline.
+      if (msg.key.fromMe) {
+        if (msg.key?.id && !session.ownSentIds.has(msg.key.id)) {
+          handlePhoneSentMessage({ msg, chatbotId }).catch((err) => {
+            console.error(`[PHONE-SENT] Unhandled error for ${chatbotId}:`, err.stack || err.message);
+          });
+        }
+        continue;
+      }
       if (isJidBroadcast(msg.key.remoteJid)) continue;
 
       const isGroup = isJidGroup(msg.key.remoteJid);
 
       // Extract the text body — works for plain messages and quoted replies
-      const rawText =
-        msg.message?.conversation ||
-        msg.message?.extendedTextMessage?.text ||
-        msg.message?.imageMessage?.caption ||
-        msg.message?.videoMessage?.caption ||
-        "";
+      const rawText = extractBaileysMessageText(msg);
 
       // Debug log for every inbound message so group issues are visible in pm2 logs
       if (isGroup) {
@@ -1324,8 +1464,11 @@ async function startSession(chatbotId, userId) {
       // Awaiting here blocks the Node event loop and prevents Baileys from
       // sending keepalive frames, causing the socket to time out at 60s.
       handleIncomingMessage({ msg, isGroup, userMessage, chatbotId, sock }).catch((err) => {
-        console.error(`[MSG] Unhandled error for ${chatbotId}:`, err.message);
+        console.error(`[MSG] Unhandled error for ${chatbotId}:`, err.stack || err.message);
       });
+      } catch (err) {
+        console.error(`[MSG] Sync error processing message for ${chatbotId}:`, err.stack || err.message);
+      }
     }
   });
 
@@ -1519,6 +1662,18 @@ app.delete("/wa-qr/disconnect/:chatbotId", async (req, res) => {
 
 (async () => {
   try {
+    ({
+      default: makeWASocket,
+      DisconnectReason,
+      initAuthCreds,
+      proto,
+      isJidBroadcast,
+      isJidGroup,
+      fetchLatestBaileysVersion,
+      makeCacheableSignalKeyStore,
+      Browsers,
+    } = await import("@whiskeysockets/baileys"));
+
     await connectDb();
     await restoreSessions();
     app.listen(PORT, () => {


### PR DESCRIPTION
Adds a third "Whatsapp QR" tab to Conversation History, backed by three new authenticated Next.js routes (whatsapp-qr/inbox/api, auto-reply/api) that read/write directly against whatsapp-qr-chat-history and whatsapp_qr_sessions in Mongo — the existing Normal and Whatsapp (Meta) tabs are untouched.

Per-contact AI auto-reply toggle: turning it off stops the bot from auto-replying and shows a banner telling the owner to continue the chat from their phone; messages sent either from the phone or by the contact are still captured and logged via a new fromMe-aware branch in the messages.upsert handler (session.ownSentIds dedupes AI-sent echoes from genuine phone-sent messages).

Also includes two whatsapp-server.js fixes surfaced while building this:
- Wrap per-message processing in messages.upsert in its own try/catch so one malformed message can no longer abort the rest of the batch, and log full stack traces instead of just err.message.
- Rename the new Baileys text-extraction helper to extractBaileysMessageText to stop it colliding with a pre-existing extractMessageText() used for OpenAI Assistants content parsing, which was silently shadowing it and breaking incoming-message handling.

Upgrades @whiskeysockets/baileys 6.7.18 -> 7.0.0-rc14 (loaded via dynamic import() since 7.x is ESM-only) to resolve contacts' real phone numbers (remoteJidAlt/participantAlt) instead of showing WhatsApp's opaque LID when available, with a fallback to the LID when WhatsApp doesn't supply it.